### PR TITLE
Add `run_swe_agent` to run software engineer agents during pipeline

### DIFF
--- a/docs/actions.md
+++ b/docs/actions.md
@@ -139,6 +139,9 @@ Runs unit tests for a data item.
 - `filename` (Union[Callable,Key,str]): Name of the test file
 - `dir` (Union[Callable,Key,str]): Directory containing the test file (default: `Key("context.input_dir")`)
 - `property` (Union[Callable,Key,str]): Property to store test results under (default: "test_result")
+- `sandbox` (Union[Callable,Key,str], optional): Sandbox configuration to use for isolated test execution
+- `stream_logs` (Union[Callable,Key,bool]): Whether to stream container logs (default: False)
+- `timeout` (Union[Callable,Key,int]): Timeout for execution in seconds (default: 300)
 
 ### `save_item`
 Saves a data item to a file.

--- a/docs/run_swe_agent_architecture.md
+++ b/docs/run_swe_agent_architecture.md
@@ -1,0 +1,205 @@
+# `run_swe_agent` Architecture
+
+## Overview
+
+The `run_swe_agent` action provides a flexible, containerized approach to running software
+engineering agents within the dataset_foundry framework. It supports multiple agent types and
+configurable agent implementations.
+
+## Architecture Components
+
+### 1. Core Action (`run_swe_agent.py`)
+
+The main action that orchestrates agent execution:
+
+- **Parameter Resolution**: Uses dataset_foundry's parameter resolution system
+- **Input Preparation**: Creates standardized input files (AGENTS.md, PROMPT.md, spec.yaml)
+- **Agent Execution**: Delegates to AgentRunner for containerized execution
+- **Result Processing**: Stores agent results in item data
+
+### 2. Container Management (`container_manager.py`)
+
+Handles Docker container lifecycle:
+
+- **Container Execution**: Runs containers with proper configuration
+- **Image Building**: Builds agent images from Dockerfiles
+- **Resource Management**: Manages active containers and cleanup
+- **Error Handling**: Provides robust error handling and retry logic
+
+### 3. Agent Runner (`agent_runner.py`)
+
+Orchestrates different agent types:
+
+- **Configuration Loading**: Loads agent configurations from files or built-in defaults
+- **Container Configuration**: Prepares container configs with proper volumes and environment
+- **Result Processing**: Processes container results into standardized format
+- **Agent Type Support**: Supports multiple agent types (swe_agent, refactor_agent, etc.)
+
+
+## Usage Examples
+
+### Basic Usage
+
+```python
+from dataset_foundry.actions.item.run_swe_agent import run_swe_agent
+
+# In a pipeline
+run_swe_agent(
+    instructions=Key("context.agents.instructions"),
+    prompt=Key("context.prompts.implement_spec"),
+    spec=Key("spec"),
+    output_dir=Template("{context.output_dir}/{id}"),
+    agent=Key("context.agents.agent"),
+)
+```
+
+### Configuration
+
+```yaml
+# config.yaml
+swe_agent:
+  type: "codex"
+  instructions: |-
+    # Agent instructions here
+    You are a software engineering agent...
+
+prompts:
+  implement_spec: |-
+    # Task-specific prompt here
+    Implement the following specification...
+```
+
+### Advanced Usage with Custom Agent
+
+```python
+# Custom agent configuration
+run_swe_agent(
+    instructions="Custom agent instructions",
+    prompt="Custom prompt",
+    spec={"name": "my_project", "files": [...]},
+    output_dir="/path/to/output",
+    agent="custom_agent",
+    repo_path="/path/to/existing/repo",
+    timeout=7200,
+    max_retries=5,
+    output_key="custom_result",
+)
+```
+
+## Agent Configuration
+
+### Built-in Agents
+
+#### Codex Agent (`codex`)
+- **Purpose**: OpenAI's Codex for code generation
+- **Image**: `codex-agent:latest`
+- **Entrypoint**: `bash -c "cat /workspace/PROMPT.md | codex exec --skip-git-repo-check"`
+- **Capabilities**: AI-powered code generation using OpenAI's Codex
+- **Requirements**: `OPENAI_API_KEY` environment variable
+
+### Custom Agent Configuration
+
+The agent configuration is automatically derived from the agent name. For example, if you specify
+`agent="my_custom_agent"`, the system will look for configuration in
+`src/dataset_foundry/configs/agents/my_custom_agent/agent.yml`.
+
+To add a custom agent, create the directory structure:
+
+```
+configs/agents/my_custom_agent/
+├── agent.yml          # Agent configuration
+├── Dockerfile         # Docker image definition
+└── agent/
+    └── main.py        # Custom agent entry point, if not installed by Dockerfile
+```
+
+The `agent.yml` file should contain:
+
+```yaml
+image: "my-custom-agent:latest"
+dockerfile_path: "src/dataset_foundry/configs/agents/my_custom_agent"
+working_dir: "/workspace"
+environment:
+  PYTHONPATH: "/workspace"
+  LANG: "en_US.UTF-8"
+volumes:
+  "/tmp": {"bind": "/tmp", "mode": "rw"}
+entrypoint: ["python", "-m", "agent.main"]
+
+# Or for a CLI tool that reads from stdin
+image: "my-cli-agent:latest"
+dockerfile_path: "src/dataset_foundry/configs/agents/my_cli_agent"
+working_dir: "/workspace"
+environment:
+  API_KEY: "${API_KEY}"
+volumes:
+  "/tmp": {"bind": "/tmp", "mode": "rw"}
+entrypoint: ["bash", "-c", "cat /workspace/PROMPT.md | my-cli-tool --config /workspace/spec.yaml"]
+```
+
+The agent runner will automatically load the configuration from this path. All agent behavior,
+including command structure, environment variables, and execution patterns, is defined in the
+`agent.yml` file.
+
+### Environment Variables
+
+Some agents require environment variables to function properly. The agent runner supports
+environment variable substitution:
+
+```yaml
+environment:
+  OPENAI_API_KEY: "${OPENAI_API_KEY}"  # Will be replaced with system environment variable
+  CUSTOM_VAR: "static_value"           # Will be used as-is
+```
+
+The system will automatically inject environment variables from the host system into the container.
+
+### Agent Directory Structure
+
+```
+configs/agents/
+└── codex/
+    ├── agent.yml          # Agent configuration
+    └── Dockerfile         # Docker image definition
+```
+
+## Input/Output Interface
+
+### Input Files
+
+The action creates these files in the agent's workspace:
+
+- **AGENTS.md**: General operating instructions
+- **PROMPT.md**: Task-specific prompt
+- **spec.yaml**: Specification data (JSON/YAML)
+- **repo/**: Optional existing repository
+
+### Typical Output Structure
+
+```
+output_dir/
+├── AGENTS.md
+├── PROMPT.md
+├── spec.yaml
+├── repo/
+│   └── (generated repo files)
+└── build-info
+    ├── agent_metadata.yaml
+    └── agent_results.yaml
+```
+
+### Result Data
+
+The action stores results in item data:
+
+```python
+{
+    "agent_result": AgentResult,
+    "agent_result_metadata": {
+        "agent": "codex",
+        "output_dir": "/path/to/output",
+        "attempts": 1,
+        "success": True
+    }
+}
+```

--- a/examples/refactorable_code/generate_repo_from_spec_with_swe_agent/config.yaml
+++ b/examples/refactorable_code/generate_repo_from_spec_with_swe_agent/config.yaml
@@ -1,6 +1,7 @@
 prompts:
   implement_spec: |-
-    You are a software engineering agent tasked with implementing a complete repository based on a specification.
+    You are a software engineering agent tasked with implementing a complete repository based on a
+    specification.
 
     Your task is to:
     1. Analyze the provided specification
@@ -9,9 +10,9 @@ prompts:
     4. Include comprehensive unit tests
     5. Ensure the code follows best practices
 
-    The specification will be provided in the spec.yaml file, and general instructions in AGENTS.md.
+    The specification is in `input/spec.yaml`, and general instructions are in `input/AGENTS.md`.
 
-    Please implement the complete repository and save all files to the `./repo` directory.
+    Please implement the complete repository and save all files to the './repo' directory.
 
 swe_agent:
   type: "codex"

--- a/examples/refactorable_code/generate_repo_from_spec_with_swe_agent/config.yaml
+++ b/examples/refactorable_code/generate_repo_from_spec_with_swe_agent/config.yaml
@@ -1,0 +1,57 @@
+prompts:
+  implement_spec: |-
+    You are a software engineering agent tasked with implementing a complete repository based on a specification.
+
+    Your task is to:
+    1. Analyze the provided specification
+    2. Create a complete repository structure
+    3. Implement all required files with proper code
+    4. Include comprehensive unit tests
+    5. Ensure the code follows best practices
+
+    The specification will be provided in the spec.yaml file, and general instructions in AGENTS.md.
+
+    Please implement the complete repository and save all files to the `./repo` directory.
+
+swe_agent:
+  type: "codex"
+  instructions: |-
+    # Agent Instructions
+
+    You are a sophisticated AI-powered software engineering agent that automates code implementation through intelligent planning and execution.
+
+    ## Capabilities
+    - Intelligent code planning and analysis
+    - Automated code generation with best practices
+    - Multi-agent workflow for planning and implementation
+    - Codebase understanding and semantic search
+    - Incremental development with atomic task breakdown
+
+    ## Workflow
+    1. **Research & Planning**: Analyze requirements and create detailed implementation plans
+    2. **Implementation**: Execute plans with precise file modifications
+    3. **Validation**: Ensure code quality and test coverage
+
+    ## Guidelines
+    - Follow the specification exactly
+    - Use modern programming practices
+    - Include comprehensive error handling
+    - Write clear, maintainable code
+    - Include proper documentation
+    - Create thorough unit tests
+    - Use appropriate design patterns
+
+    ## Output Requirements
+    - Generate all files specified in the spec
+    - Include proper imports and dependencies
+    - Ensure code is functional and testable
+    - Follow the specified file structure
+    - Include README with usage instructions
+
+    ## Code Quality Standards
+    - Use descriptive variable and function names
+    - Include type hints where appropriate
+    - Follow PEP 8 style guidelines
+    - Add docstrings for all functions and classes
+    - Handle edge cases and error conditions
+    - Optimize for readability and maintainability

--- a/examples/refactorable_code/generate_repo_from_spec_with_swe_agent/config.yaml
+++ b/examples/refactorable_code/generate_repo_from_spec_with_swe_agent/config.yaml
@@ -15,7 +15,6 @@ prompts:
     Please implement the complete repository and save all files to the './repo' directory.
 
 swe_agent:
-  type: "codex"
   instructions: |-
     # Agent Instructions
 

--- a/examples/refactorable_code/generate_repo_from_spec_with_swe_agent/pipeline.py
+++ b/examples/refactorable_code/generate_repo_from_spec_with_swe_agent/pipeline.py
@@ -1,0 +1,53 @@
+from pathlib import Path
+
+from dataset_foundry.actions.dataset.load_dataset_from_directory import load_dataset_from_directory
+from dataset_foundry.actions.item.log_item import log_item
+from dataset_foundry.actions.item.set_item_metadata import set_item_metadata
+from dataset_foundry.actions.item.run_swe_agent import run_swe_agent
+from dataset_foundry.actions.item.save_item import save_item
+from dataset_foundry.core.key import Key
+from dataset_foundry.core.template import Template
+from dataset_foundry.core.item_pipeline import ItemPipeline
+
+pipeline = ItemPipeline(
+    name="generate_repo_from_spec_with_swe_agent",
+    metadata={
+        "version": "0.1.0",
+        "author": "fastfedora",
+        "description": "Generate complete repositories from specifications using SWE Agent",
+    },
+    config=Path(__file__).parent / "config.yaml",
+    setup=[
+        load_dataset_from_directory(
+            include="spec_{id}.yaml",
+            property="spec",
+            merge=True,
+        ),
+    ],
+    steps=[
+        log_item(message=Template("Generating repository with SWE Agent for {id}...")),
+        set_item_metadata(),
+        run_swe_agent(
+            instructions=Key("context.swe_agent.instructions"),
+            prompt=Key("context.prompts.implement_spec"),
+            spec=Key("spec"),
+            output_dir=Template("{context.output_dir}/{id}"),
+            agent=Key("context.swe_agent.type"),
+            timeout=7200,  # 2 hours
+            max_retries=1,
+            output_key="agent_result",
+            stream_logs=True,
+        ),
+        save_item(
+            contents=Key("agent_result_metadata"),
+            filename=Template("{id}/build-info/agent_metadata.yaml"),
+            format="yaml"
+        ),
+        save_item(
+            contents=Key("agent_result"),
+            filename=Template("{id}/build-info/agent_result.yaml"),
+            format="yaml"
+        ),
+        log_item(message=Template("Repository generation completed for {id}")),
+    ]
+)

--- a/pyproject.toml
+++ b/pyproject.toml
@@ -8,6 +8,7 @@ authors = [
 ]
 requires-python = ">=3.12"
 dependencies = [
+    "datason>=0.13.0",
     "docker>=7.1.0",
     "langchain==0.3.21",
     "langchain-anthropic==0.3.10",

--- a/pyproject.toml
+++ b/pyproject.toml
@@ -8,6 +8,7 @@ authors = [
 ]
 requires-python = ">=3.12"
 dependencies = [
+    "docker>=7.1.0",
     "langchain==0.3.21",
     "langchain-anthropic==0.3.10",
     "langchain-core==0.3.45",

--- a/pyproject.toml
+++ b/pyproject.toml
@@ -14,6 +14,7 @@ dependencies = [
     "langchain-openai==0.3.9",
     "pydantic>=2.10.6",
     "pytest>=8.3.4",
+    "pytest-asyncio>=1.0.0",
     "python-dotenv==1.0.1",
     "PyYAML==6.0.2",
     "toolz>=1.0.0",

--- a/src/dataset_foundry/actions/dataset/generate_dataset.py
+++ b/src/dataset_foundry/actions/dataset/generate_dataset.py
@@ -1,3 +1,4 @@
+from datetime import datetime
 import re
 import logging
 from typing import Callable, Optional, Union
@@ -10,6 +11,7 @@ from ...core.dataset_item import DatasetItem
 from ...core.key import Key
 from ...types.dataset_action import DatasetAction
 from ...utils.params.resolve_dataset_value import resolve_dataset_value
+from ...utils.get_pipeline_metadata import get_pipeline_metadata
 
 variable_regex = r'\{([^}]+)\}'
 
@@ -20,12 +22,34 @@ def generate_dataset(
         model: Union[Callable,Key,str] = Key("context.model"),
         parser: Optional[Union[Callable,Key,str]] = None,
         output_key: Optional[Union[Callable,Key,str]] = None,
+        dataset_metadata_key: Optional[Union[Callable,Key,str]] = None,
+        dataset_chat_key: Optional[Union[Callable,Key,str]] = "chat",
     ) -> DatasetAction:
+    """
+    Generate a dataset by given a prompt to a model and parsing the response.
+
+    Args:
+        prompt: A dataset generation prompt template.
+        model: The model to use for generation.
+        parser: The parser to parse the response with, if any.
+        output_key: The key under which to save the content in each data item. If not provided
+            and not using a custom parser, the content will be saved under the key "output".
+        dataset_metadata_key: The key to use for the dataset metadata. If not provided, the
+            metadata will be merged with the existing metadata instead.
+        dataset_chat_key: The key to save the chat messages used to generate the dataset. If not
+            provided, the chat messages will not be saved.
+
+    Returns:
+        A dataset action that can be used to generate a dataset.
+    """
+
     async def generate_dataset_action(dataset: Dataset, context: Context):
         resolved_prompt = resolve_dataset_value(prompt, dataset, context, required_as="prompt")
         resolved_model = resolve_dataset_value(model, dataset, context, required_as="model")
         resolved_parser = resolve_dataset_value(parser, dataset, context)
         resolved_output_key = resolve_dataset_value(output_key, dataset, context)
+        resolved_dataset_metadata_key = resolve_dataset_value(dataset_metadata_key, dataset, context)
+        resolved_dataset_chat_key = resolve_dataset_value(dataset_chat_key, dataset, context)
 
         # Build the prompt
         variables = re.findall(variable_regex, resolved_prompt)
@@ -63,5 +87,25 @@ def generate_dataset(
                 { resolved_output_key: content } if resolved_output_key else content
             )
             dataset.add(item)
+
+        metadata = {
+            "num_samples": len(contents),
+            "pipeline": get_pipeline_metadata(context),
+            "model": context.model.info,
+            "created_at": datetime.now().isoformat(),
+        }
+
+        dataset.metadata.update(
+            { resolved_dataset_metadata_key: metadata }
+            if resolved_dataset_metadata_key else metadata
+        )
+
+        if resolved_dataset_chat_key:
+            dataset.metadata.update({
+                resolved_dataset_chat_key: {
+                    "messages": messages,
+                    "response": response,
+                },
+            })
 
     return generate_dataset_action

--- a/src/dataset_foundry/actions/dataset/load_dataset.py
+++ b/src/dataset_foundry/actions/dataset/load_dataset.py
@@ -15,18 +15,23 @@ logger = logging.getLogger(__name__)
 def load_dataset(
         filename: Union[Callable,Key,str] = "dataset.yaml",
         dir: Union[Callable,Key,str] = Key("context.input_dir"),
+        items_key: Union[Callable,Key,str] = None,
         property: Union[Callable,Key,str] = None,
         id_generator: Callable = lambda index, _data: f"{index+1:03d}",
     ) -> DatasetAction:
     async def load_dataset_action(dataset: Dataset, context: Context):
         resolved_dir = resolve_dataset_value(dir, dataset, context, required_as="dir")
         resolved_file = resolve_dataset_value(filename, dataset, context, required_as="filename")
+        resolved_items_key = resolve_dataset_value(items_key, dataset, context)
         resolved_property = resolve_dataset_value(property, dataset, context)
 
         path = resolved_dir / resolved_file
         logger.debug(f"Loading data from {path}")
         with open(path) as file:
             dataset_items = yaml.safe_load(file)
+
+        if resolved_items_key:
+            dataset_items = dataset_items[resolved_items_key]
 
         if not isinstance(dataset_items, list):
             raise ValueError(f"The dataset at {path} must be a list")

--- a/src/dataset_foundry/actions/dataset/load_dataset_from_directory.py
+++ b/src/dataset_foundry/actions/dataset/load_dataset_from_directory.py
@@ -1,4 +1,4 @@
-import json
+import datason.json as json
 import logging
 from typing import Callable, Literal, Optional, Union
 import yaml

--- a/src/dataset_foundry/actions/dataset/load_dataset_metadata.py
+++ b/src/dataset_foundry/actions/dataset/load_dataset_metadata.py
@@ -1,4 +1,4 @@
-import json
+import datason.json as json
 import logging
 from typing import Callable, Union
 import yaml

--- a/src/dataset_foundry/actions/dataset/save_dataset_chat.py
+++ b/src/dataset_foundry/actions/dataset/save_dataset_chat.py
@@ -1,0 +1,26 @@
+from typing import Callable, Optional, Union
+
+from ...core.context import Context
+from ...core.dataset import Dataset
+from ...core.key import Key
+from ...types.dataset_action import DatasetAction
+from ...utils.params.resolve_dataset_value import resolve_dataset_value
+from ...utils.save_messages import save_messages
+from ...utils.format.format_template import format_template
+
+def save_dataset_chat(
+        dir: Union[Callable,Key,str] = Key("context.log_dir"),
+        filename: Union[Callable,Key,str] = "log.yaml",
+        chat_key: Union[Callable,Key,str] = "chat",
+    ) -> DatasetAction:
+    async def save_dataset_chat_action(dataset: Dataset, context: Context):
+        resolved_dir = resolve_dataset_value(dir, dataset, context, required_as="dir")
+        resolved_filename = resolve_dataset_value(filename, dataset, context, required_as="filename")
+        resolved_chat_key = resolve_dataset_value(chat_key, dataset, context, required_as="chat_key")
+
+        log_file = resolved_dir / resolved_filename
+        chat = dataset.metadata[resolved_chat_key]
+
+        save_messages(log_file, chat["messages"], chat["response"].content)
+
+    return save_dataset_chat_action

--- a/src/dataset_foundry/actions/item/exec_item.py
+++ b/src/dataset_foundry/actions/item/exec_item.py
@@ -1,0 +1,67 @@
+import logging
+from typing import Callable, Optional, Union
+import subprocess
+import asyncio
+from pathlib import Path
+
+from ...core.context import Context
+from ...core.dataset_item import DatasetItem
+from ...core.key import Key
+from ...types.item_action import ItemAction
+from ...utils.params.resolve_item_value import resolve_item_value
+
+logger = logging.getLogger(__name__)
+
+def exec_item(
+        command: Union[Callable, Key, str],
+        cwd: Optional[Union[Callable, Key, str]] = Key("context.output_dir"),
+        output_key: Union[Callable, Key, str] = "exec_result",
+    ) -> ItemAction:
+    """
+    Runs a shell command in the specified working directory and stores the result in the item.
+
+    Args:
+        command: The shell command to run (string or callable/key).
+        cwd: The working directory to run the command in (string or callable/key).
+        output_key: The key to store the result under in the item (default: 'exec_result').
+    """
+    async def exec_item_action(item: DatasetItem, context: Context):
+        resolved_command = resolve_item_value(command, item, context, required_as="command")
+        resolved_cwd = resolve_item_value(cwd, item, context, required_as="cwd")
+        resolved_output_key = resolve_item_value(output_key, item, context)
+
+        if isinstance(resolved_cwd, str):
+            resolved_cwd = Path(resolved_cwd)
+
+        logger.info(f"Running command: {resolved_command} (cwd={resolved_cwd})")
+
+        def run_command():
+            try:
+                result = subprocess.run(
+                    resolved_command,
+                    shell=True,
+                    cwd=resolved_cwd,
+                    capture_output=True,
+                    text=True,
+                )
+                return {
+                    "command": resolved_command,
+                    "cwd": str(resolved_cwd),
+                    "returncode": result.returncode,
+                    "stdout": result.stdout,
+                    "stderr": result.stderr,
+                }
+            except Exception as e:
+                return {
+                    "command": resolved_command,
+                    "cwd": str(resolved_cwd),
+                    "returncode": -1,
+                    "stdout": "",
+                    "stderr": str(e),
+                }
+
+        exec_result = await asyncio.to_thread(run_command)
+
+        item.push({ resolved_output_key: exec_result }, exec_item)
+
+    return exec_item_action

--- a/src/dataset_foundry/actions/item/foreach_item_element.py
+++ b/src/dataset_foundry/actions/item/foreach_item_element.py
@@ -1,0 +1,52 @@
+import logging
+from typing import Callable, Union
+
+from ...core.context import Context
+from ...core.dataset_item import DatasetItem
+from ...core.key import Key
+from ...types.item_action import ItemAction
+from ...utils.params.resolve_item_value import resolve_item_value
+
+logger = logging.getLogger(__name__)
+
+def foreach_item_element(
+        collection: Union[Callable, Key, list, tuple],
+        actions: list,
+    ) -> ItemAction:
+    """
+    Creates an action that executes a list of actions on each element in a collection belonging to
+    the current item.
+
+    Args:
+        collection (Union[Callable, Key, list, tuple]): The collection to iterate over.
+        actions (list): A list of actions to execute for each element in the collection.
+
+    Returns:
+        function: A function that takes a DatasetItem and Context and executes the actions
+            for each element in the collection belonging to the current item.
+    """
+    async def foreach_item_element_action(item: DatasetItem, context: Context):
+        resolved_collection = resolve_item_value(collection, item, context)
+
+        if not isinstance(resolved_collection, (list, tuple)):
+            raise ValueError("'collection' is not iterable; it must resolve to a list or tuple")
+
+        logger.debug(f"Executing foreach over {len(resolved_collection)} items")
+
+        for index, element in enumerate(resolved_collection):
+            element_item = DatasetItem(
+                id=f"{item.id}_{index}",
+                data={
+                    'parent': item,
+                    'index': index,
+                    'element': element,
+                }
+            )
+
+            for action in actions:
+                await action(element_item, context)
+
+            # TODO: Maybe store the result of any changes to `element` in the item data. If so,
+            #       save a copy of `element` in the `DataItem` above. [fastfedora 14.Jul.25]
+
+    return foreach_item_element_action

--- a/src/dataset_foundry/actions/item/load_item.py
+++ b/src/dataset_foundry/actions/item/load_item.py
@@ -1,4 +1,4 @@
-import json
+import datason.json as json
 import logging
 from typing import Callable, Literal, Optional, Union
 import yaml

--- a/src/dataset_foundry/actions/item/parse_item.py
+++ b/src/dataset_foundry/actions/item/parse_item.py
@@ -1,5 +1,5 @@
 from typing import Callable, Optional, Union
-import json
+import datason.json as json
 import yaml
 
 from ...core.context import Context

--- a/src/dataset_foundry/actions/item/run_swe_agent.py
+++ b/src/dataset_foundry/actions/item/run_swe_agent.py
@@ -77,6 +77,8 @@ def run_swe_agent(
 
         for attempt in range(resolved_max_retries):
             try:
+                agent_inputs.context_data["attempt"] = attempt + 1
+
                 result = await agent_runner.run_agent(
                     inputs=agent_inputs,
                     output_dir=output_path,
@@ -94,12 +96,6 @@ def run_swe_agent(
 
         item.push({
             resolved_output_key: result,
-            f"{resolved_output_key}_metadata": {
-                "agent": resolved_agent,
-                "output_dir": str(output_path),
-                "attempts": attempt + 1,
-                "success": result is not None
-            }
         }, run_swe_agent)
 
     return run_swe_agent_action
@@ -147,6 +143,7 @@ async def _prepare_agent_inputs(
         output_dir=str(output_dir),
         item_id=item.id,
         context_data={
+            "attempt": 0,
             "id": item.id,
             **item.data,
             # TODO: Think about adding `context` in here too. [fastfedora 18.Jul.25]

--- a/src/dataset_foundry/actions/item/run_swe_agent.py
+++ b/src/dataset_foundry/actions/item/run_swe_agent.py
@@ -116,11 +116,13 @@ async def _prepare_agent_inputs(
 ) -> AgentInputs:
     """Prepare input files for the agent."""
 
-    instructions_file = output_dir / "AGENTS.md"
+    inputs_dir = output_dir / "input"
+    inputs_dir.mkdir(parents=True, exist_ok=True)
+
+    instructions_file = inputs_dir / "AGENTS.md"
     instructions_file.write_text(instructions)
 
-
-    spec_file = output_dir / "spec.yaml"
+    spec_file = inputs_dir / "spec.yaml"
     if isinstance(spec, dict):
         with open(spec_file, 'w') as f:
             yaml.dump(spec, f, default_flow_style=False)

--- a/src/dataset_foundry/actions/item/run_swe_agent.py
+++ b/src/dataset_foundry/actions/item/run_swe_agent.py
@@ -119,8 +119,6 @@ async def _prepare_agent_inputs(
     instructions_file = output_dir / "AGENTS.md"
     instructions_file.write_text(instructions)
 
-    prompt_file = output_dir / "PROMPT.md"
-    prompt_file.write_text(prompt)
 
     spec_file = output_dir / "spec.yaml"
     if isinstance(spec, dict):
@@ -140,8 +138,8 @@ async def _prepare_agent_inputs(
                 shutil.copy2(repo_source, repo_dest)
 
     return AgentInputs(
+        prompt=prompt,
         instructions_file=str(instructions_file),
-        prompt_file=str(prompt_file),
         spec_file=str(spec_file),
         repo_path=str(output_dir / "repo") if repo_path else None,
         output_dir=str(output_dir),

--- a/src/dataset_foundry/actions/item/run_swe_agent.py
+++ b/src/dataset_foundry/actions/item/run_swe_agent.py
@@ -1,0 +1,154 @@
+from typing import Callable, Union, Optional
+from pathlib import Path
+import asyncio
+import shutil
+import yaml
+
+from ...core.context import Context
+from ...core.dataset_item import DatasetItem
+from ...core.key import Key
+from ...types.item_action import ItemAction
+from ...utils.params.resolve_item_value import resolve_item_value
+from ...utils.format.format_template import format_template
+from ...utils.docker.agent_runner import AgentRunner, AgentInputs
+from ...utils.docker.container_manager import ContainerManager
+
+def run_swe_agent(
+        instructions: Union[Callable, Key, str] = Key("context.swe_agent.instructions"),
+        prompt: Union[Callable, Key, str] = Key("context.prompts.implement_spec"),
+        spec: Union[Callable, Key, str, dict] = Key("spec"),
+        output_dir: Union[Callable, Key, str] = Key("context.output_dir"),
+        agent: Union[Callable, Key, str] = Key("context.swe_agent.type"),
+        repo_path: Optional[Union[Callable, Key, str]] = None,
+        timeout: Union[Callable, Key, int] = 3600,  # 1 hour default
+        max_retries: Union[Callable, Key, int] = 3,
+        output_key: Union[Callable, Key, str] = "agent_result",
+        stream_logs: Union[Callable, Key, bool] = False,
+    ) -> ItemAction:
+    """
+    Run a software engineering agent in a Docker container.
+
+    Args:
+        instructions: General operating instructions for the agent (rendered as AGENTS.md)
+        prompt: The specific prompt that references the spec
+        spec: Specification data (string or dict, rendered as JSON/YAML)
+        output_dir: Directory where agent output should be saved
+        agent: Name of the agent to run (e.g., "codex", "claude-code")
+        repo_path: Optional path to pre-existing repository
+        timeout: Maximum execution time in seconds
+        max_retries: Maximum number of retry attempts
+        output_key: Key to store the agent result in item data
+        stream_logs: Whether to stream container logs to logger.info (default: False)
+    """
+
+    async def run_swe_agent_action(item: DatasetItem, context: Context):
+        resolved_instructions = resolve_item_value(instructions, item, context, required_as="instructions")
+        resolved_prompt = resolve_item_value(prompt, item, context, required_as="prompt")
+        resolved_spec = resolve_item_value(spec, item, context, required_as="spec")
+        resolved_output_dir = resolve_item_value(output_dir, item, context, required_as="output_dir")
+        resolved_agent = resolve_item_value(agent, item, context, required_as="agent")
+        resolved_repo_path = resolve_item_value(repo_path, item, context) if repo_path else None
+        resolved_timeout = resolve_item_value(timeout, item, context)
+        resolved_max_retries = resolve_item_value(max_retries, item, context)
+        resolved_output_key = resolve_item_value(output_key, item, context)
+        resolved_stream_logs = resolve_item_value(stream_logs, item, context)
+
+        if isinstance(resolved_output_dir, str):
+            resolved_output_dir = format_template(resolved_output_dir, {
+                "id": item.id,
+                **item.data
+            })
+
+        output_path = Path(resolved_output_dir)
+        output_path.mkdir(parents=True, exist_ok=True)
+
+        agent_inputs = await _prepare_agent_inputs(
+            item, context, resolved_instructions, resolved_prompt,
+            resolved_spec, output_path, resolved_repo_path
+        )
+        agent_runner = AgentRunner(
+            agent_type=resolved_agent,
+            container_manager=ContainerManager()
+        )
+
+        # Execute agent with retry logic
+        result = None
+        last_error = None
+
+        for attempt in range(resolved_max_retries):
+            try:
+                result = await agent_runner.run_agent(
+                    inputs=agent_inputs,
+                    output_dir=output_path,
+                    timeout=resolved_timeout,
+                    attempt=attempt + 1,
+                    stream_logs=resolved_stream_logs
+                )
+                break
+            except Exception as e:
+                last_error = e
+                if attempt < resolved_max_retries - 1:
+                    await asyncio.sleep(2 ** attempt)  # Exponential backoff
+                else:
+                    raise last_error
+
+        item.push({
+            resolved_output_key: result,
+            f"{resolved_output_key}_metadata": {
+                "agent": resolved_agent,
+                "output_dir": str(output_path),
+                "attempts": attempt + 1,
+                "success": result is not None
+            }
+        }, run_swe_agent)
+
+    return run_swe_agent_action
+
+
+async def _prepare_agent_inputs(
+    item: DatasetItem,
+    context: Context,
+    instructions: str,
+    prompt: str,
+    spec: Union[str, dict],
+    output_dir: Path,
+    repo_path: Optional[str] = None
+) -> AgentInputs:
+    """Prepare input files for the agent."""
+
+    instructions_file = output_dir / "AGENTS.md"
+    instructions_file.write_text(instructions)
+
+    prompt_file = output_dir / "PROMPT.md"
+    prompt_file.write_text(prompt)
+
+    spec_file = output_dir / "spec.yaml"
+    if isinstance(spec, dict):
+        with open(spec_file, 'w') as f:
+            yaml.dump(spec, f, default_flow_style=False)
+    else:
+        spec_file.write_text(str(spec))
+
+    # Copy existing repo if provided
+    if repo_path:
+        repo_source = Path(repo_path)
+        if repo_source.exists():
+            repo_dest = output_dir / "repo"
+            if repo_source.is_dir():
+                shutil.copytree(repo_source, repo_dest, dirs_exist_ok=True)
+            else:
+                shutil.copy2(repo_source, repo_dest)
+
+    return AgentInputs(
+        instructions_file=str(instructions_file),
+        prompt_file=str(prompt_file),
+        spec_file=str(spec_file),
+        repo_path=str(output_dir / "repo") if repo_path else None,
+        output_dir=str(output_dir),
+        item_id=item.id,
+        context_data={
+            "id": item.id,
+            **item.data,
+            # TODO: Think about adding `context` in here too. [fastfedora 18.Jul.25]
+        }
+    )

--- a/src/dataset_foundry/actions/item/run_swe_agent.py
+++ b/src/dataset_foundry/actions/item/run_swe_agent.py
@@ -79,7 +79,7 @@ def run_swe_agent(
             try:
                 agent_inputs.context_data["attempt"] = attempt + 1
 
-                result = await agent_runner.run_agent(
+                result = await agent_runner.run(
                     inputs=agent_inputs,
                     output_dir=output_path,
                     timeout=resolved_timeout,

--- a/src/dataset_foundry/actions/item/run_unit_tests.py
+++ b/src/dataset_foundry/actions/item/run_unit_tests.py
@@ -1,4 +1,5 @@
-from typing import Callable, Union
+from typing import Callable, Union, Optional, List
+from pathlib import Path
 
 from ...core.context import Context
 from ...core.dataset_item import DatasetItem
@@ -6,19 +7,46 @@ from ...core.key import Key
 from ...types.item_action import ItemAction
 from ...utils.params.resolve_item_value import resolve_item_value
 from ...utils.unit_tests.run_python_unit_tests import run_python_unit_tests
-from ...utils.format.format_template import format_template
+from ...utils.unit_tests.parse_python_unit_test_results import parse_python_unit_test_results
+from ...utils.docker.sandbox_runner import SandboxRunner
 
 def run_unit_tests(
         filename: Union[Callable,Key,str],
         dir: Union[Callable,Key,str] = Key("context.input_dir"),
         property: Union[Callable,Key,str] = "test_result",
+        sandbox: Optional[Union[Callable,Key,str]] = None,
+        stream_logs: Union[Callable,Key,bool] = False,
+        timeout: Union[Callable,Key,int] = 300,
     ) -> ItemAction:
     async def run_unit_tests_action(item: DatasetItem, context: Context):
         resolved_filename = resolve_item_value(filename, item, context, required_as="filename")
         resolved_dir = resolve_item_value(dir, item, context, required_as="dir")
         resolved_property = resolve_item_value(property, item, context, required_as="property")
+        resolved_sandbox = resolve_item_value(sandbox, item, context)
+        resolved_stream_logs = resolve_item_value(stream_logs, item, context)
+        resolved_timeout = resolve_item_value(timeout, item, context)
 
-        result = run_python_unit_tests(resolved_dir / resolved_filename)
+        if resolved_sandbox:
+            # Run tests in sandbox
+            if isinstance(resolved_sandbox, str):
+                sandbox_manager = SandboxRunner(resolved_sandbox)
+            else:
+                raise ValueError("Sandbox must be a string name of a sandbox")
+
+            command = ["python", "-m", "pytest", "-v", resolved_filename]
+            sandbox_result = await sandbox_manager.run(
+                target_file=resolved_filename,
+                workspace_dir=resolved_dir,
+                command=command,
+                timeout=resolved_timeout,
+                stream_logs=resolved_stream_logs
+            )
+
+            result = parse_python_unit_test_results(sandbox_result)
+            result.command = command
+        else:
+            # Run tests locally
+            result = run_python_unit_tests(Path(resolved_dir) / resolved_filename)
 
         item.push({ resolved_property: result }, run_unit_tests)
 

--- a/src/dataset_foundry/actions/item/save_item.py
+++ b/src/dataset_foundry/actions/item/save_item.py
@@ -19,7 +19,7 @@ def save_item(
     async def save_item_action(item: DatasetItem, context: Context):
         resolved_dir = resolve_item_value(dir, item, context, required_as="dir")
         resolved_filename = resolve_item_value(filename, item, context, required_as="filename")
-        resolved_contents = resolve_item_value(contents, item, context) or item.data
+        resolved_contents = resolve_item_value(contents, item, context) or '' if contents else item.data
         resolved_format = resolve_item_value(format, item, context)
 
         if resolved_format == "auto":

--- a/src/dataset_foundry/actions/item/save_item.py
+++ b/src/dataset_foundry/actions/item/save_item.py
@@ -1,5 +1,5 @@
 from typing import Callable, Optional, Union, Literal
-import json
+import datason.json as json
 import yaml
 
 from ...core.context import Context

--- a/src/dataset_foundry/actions/item/set_item_metadata.py
+++ b/src/dataset_foundry/actions/item/set_item_metadata.py
@@ -5,16 +5,8 @@ from ...core.context import Context
 from ...core.dataset_item import DatasetItem
 from ...core.key import Key
 from ...types.item_action import ItemAction
+from ...utils.get_pipeline_metadata import get_pipeline_metadata
 from ...utils.params.resolve_item_value import resolve_item_value
-
-def get_pipeline_metadata(context: Context) -> dict:
-    parent_metadata = get_pipeline_metadata(context.parent) if context.parent else None
-
-    return {
-        "name": context.pipeline.name,
-        **context.pipeline.metadata,
-        **({ "parent": parent_metadata } if parent_metadata else {}),
-    }
 
 def set_item_metadata(
         property: Union[Callable,Key,str] = "metadata",

--- a/src/dataset_foundry/configs/agents/claude_code/Dockerfile
+++ b/src/dataset_foundry/configs/agents/claude_code/Dockerfile
@@ -8,21 +8,25 @@ ENV PYTHONUNBUFFERED="1"
 ENV PYTHONDONTWRITEBYTECODE="1"
 
 # Install basic development tools and iptables/ipset
-RUN apt-get update && apt-get install -y less \
-  git \
-  procps \
-  sudo \
-  man-db \
-  unzip \
-  gnupg2 \
-  gh \
-  iptables \
-  ipset \
-  iproute2 \
-  dnsutils \
-  aggregate \
-  jq \
-  yq
+RUN set -eu; \
+  apt-get update; \
+  apt-get install -y --no-install-recommends \
+    less \
+    git \
+    procps \
+    sudo \
+    man-db \
+    unzip \
+    gnupg2 \
+    gh \
+    iptables \
+    ipset \
+    iproute2 \
+    dnsutils \
+    aggregate \
+    jq \
+    yq; \
+  rm -rf /var/lib/apt/lists/*;
 
 # Install Python globally along with modules commonly used for development
 RUN set -eu; \

--- a/src/dataset_foundry/configs/agents/claude_code/Dockerfile
+++ b/src/dataset_foundry/configs/agents/claude_code/Dockerfile
@@ -24,9 +24,21 @@ RUN apt-get update && apt-get install -y less \
   jq \
   yq
 
-# Install packages the agent might need
-RUN apt-get install -y pip \
-  python3.11-venv
+# Install Python globally along with modules commonly used for development
+RUN set -eu; \
+  apt-get update; \
+  apt-get install -y --no-install-recommends \
+    python3.11 \
+    python3.11-dev \
+    python3.11-venv \
+    python3-pip \
+    python3-pytest \
+    python3-pytest-cov; \
+  rm -rf /var/lib/apt/lists/*;
+
+# Create python symlink for compatibility
+RUN ln -sf /usr/bin/python3.11 /usr/bin/python && \
+  ln -sf /usr/bin/pip3 /usr/bin/pip
 
 # Ensure default node user has access to /usr/local/share
 RUN mkdir -p /usr/local/share/npm-global && \

--- a/src/dataset_foundry/configs/agents/claude_code/Dockerfile
+++ b/src/dataset_foundry/configs/agents/claude_code/Dockerfile
@@ -3,6 +3,10 @@ FROM node:20
 ARG TZ
 ENV TZ="$TZ"
 
+# Avoid buffering stdout and stderr and disable creating `__pycache__` directories
+ENV PYTHONUNBUFFERED="1"
+ENV PYTHONDONTWRITEBYTECODE="1"
+
 # Install basic development tools and iptables/ipset
 RUN apt-get update && apt-get install -y less \
   git \

--- a/src/dataset_foundry/configs/agents/claude_code/Dockerfile
+++ b/src/dataset_foundry/configs/agents/claude_code/Dockerfile
@@ -1,0 +1,68 @@
+FROM node:20
+
+ARG TZ
+ENV TZ="$TZ"
+
+# Install basic development tools and iptables/ipset
+RUN apt-get update && apt-get install -y less \
+  git \
+  procps \
+  sudo \
+  man-db \
+  unzip \
+  gnupg2 \
+  gh \
+  iptables \
+  ipset \
+  iproute2 \
+  dnsutils \
+  aggregate \
+  jq \
+  yq
+
+# Install packages the agent might need
+RUN apt-get install -y pip \
+  python3.11-venv
+
+# Ensure default node user has access to /usr/local/share
+RUN mkdir -p /usr/local/share/npm-global && \
+  chown -R node:node /usr/local/share
+
+ARG USERNAME=node
+
+# Create workspace and config directories and set permissions
+RUN mkdir -p /workspace /home/node/.claude && \
+  chown -R node:node /workspace /home/node/.claude
+
+WORKDIR /workspace
+
+# Install `git-delta` for better diffs
+RUN ARCH=$(dpkg --print-architecture) && \
+  wget "https://github.com/dandavison/delta/releases/download/0.18.2/git-delta_0.18.2_${ARCH}.deb" && \
+  sudo dpkg -i "git-delta_0.18.2_${ARCH}.deb" && \
+  rm "git-delta_0.18.2_${ARCH}.deb"
+
+# Set up non-root user
+USER node
+
+# Install global packages
+ENV NPM_CONFIG_PREFIX=/usr/local/share/npm-global
+ENV PATH=$PATH:/usr/local/share/npm-global/bin
+
+# Install Claude
+RUN npm install -g @anthropic-ai/claude-code
+
+# Copy firewall scripts and config file
+COPY firewall/* /usr/local/bin/firewall/
+
+USER root
+
+RUN chmod +x /usr/local/bin/firewall/init.sh && \
+  chmod +x /usr/local/bin/firewall/allow-domains.sh && \
+  echo "node ALL=(root) NOPASSWD: /usr/local/bin/firewall/init.sh" > /etc/sudoers.d/node-firewall && \
+  chmod 0440 /etc/sudoers.d/node-firewall
+
+USER node
+
+# Initialize firewall and then run the command (inserted as `$*`)
+ENTRYPOINT ["sh", "-c", "sudo /usr/local/bin/firewall/init.sh && bash -c \"$*\"", "--"]

--- a/src/dataset_foundry/configs/agents/claude_code/agent.yml
+++ b/src/dataset_foundry/configs/agents/claude_code/agent.yml
@@ -10,7 +10,7 @@ container:
     ANTHROPIC_API_KEY: "${ANTHROPIC_API_KEY}"
     NODE_OPTIONS: "--max-old-space-size=4096"
     CLAUDE_CONFIG_DIR: "/home/node/.claude"
-  command: ["claude --verbose -p --output-format stream-json --dangerously-skip-permissions \"$PROMPT\""]
+  command: ["cat input/prompt.md | claude --verbose -p --output-format stream-json --dangerously-skip-permissions"]
 
 logs:
   format: json

--- a/src/dataset_foundry/configs/agents/claude_code/agent.yml
+++ b/src/dataset_foundry/configs/agents/claude_code/agent.yml
@@ -1,0 +1,13 @@
+container:
+  image: "claude-code-agent:latest"
+  build:
+    args:
+      TZ: "${TZ:-America/Los_Angeles}"
+  cap_add:
+    - NET_ADMIN
+    - NET_RAW
+  environment:
+    ANTHROPIC_API_KEY: "${ANTHROPIC_API_KEY}"
+    NODE_OPTIONS: "--max-old-space-size=4096"
+    CLAUDE_CONFIG_DIR: "/home/node/.claude"
+  command: ["claude --dangerously-skip-permissions \"$PROMPT\""]

--- a/src/dataset_foundry/configs/agents/claude_code/agent.yml
+++ b/src/dataset_foundry/configs/agents/claude_code/agent.yml
@@ -10,4 +10,7 @@ container:
     ANTHROPIC_API_KEY: "${ANTHROPIC_API_KEY}"
     NODE_OPTIONS: "--max-old-space-size=4096"
     CLAUDE_CONFIG_DIR: "/home/node/.claude"
-  command: ["claude --dangerously-skip-permissions \"$PROMPT\""]
+  command: ["claude --verbose -p --output-format stream-json --dangerously-skip-permissions \"$PROMPT\""]
+
+logs:
+  format: json

--- a/src/dataset_foundry/configs/agents/claude_code/firewall/allow-domains.sh
+++ b/src/dataset_foundry/configs/agents/claude_code/firewall/allow-domains.sh
@@ -1,0 +1,57 @@
+#!/bin/bash
+set -euo pipefail  # Exit on error, undefined vars, and pipeline failures
+IFS=$'\n\t'        # Stricter word splitting
+
+# Accept config file as argument, default to allowed-domains.yaml in current directory
+CONFIG_FILE="${1:-firewall.yaml}"
+
+# If not fully qualified, resolve relative to current working directory
+if [[ "$CONFIG_FILE" != /* ]]; then
+    CONFIG_FILE="$(pwd)/$CONFIG_FILE"
+fi
+
+read_domains_from_yaml() {
+    local config_file="$1"
+    echo "Checking yq installed" >&2
+    if ! command -v yq >/dev/null 2>&1; then
+        echo "ERROR: yq is required to parse YAML files. Please install yq first." >&2
+        echo "Install with: pip install yq or go install github.com/mikefarah/yq/v4@latest" >&2
+        exit 1
+    fi
+    echo "Checking config file exists: $config_file" >&2
+    if [ ! -f "$config_file" ]; then
+        echo "ERROR: YAML config file not found: $config_file" >&2
+        exit 1
+    fi
+    echo "Attempting to parse YAML file: $config_file" >&2
+    yq -r '.allowed_domains[]' "$config_file" | grep -v '^$' | grep -v '^#'
+}
+
+resolve_and_add_domains() {
+    local domains="$1"
+    echo "Resolving and adding domains to ipset..."
+    while read -r domain; do
+        if [ -z "$domain" ]; then
+            continue
+        fi
+        echo "Resolving $domain..."
+        ips=$(dig +short A "$domain")
+        if [ -z "$ips" ]; then
+            echo "ERROR: Failed to resolve $domain" >&2
+            # exit 1
+        else
+            while read -r ip; do
+                if [[ ! "$ip" =~ ^[0-9]{1,3}\.[0-9]{1,3}\.[0-9]{1,3}\.[0-9]{1,3}$ ]]; then
+                    echo "ERROR: Invalid IP from DNS for $domain: $ip" >&2
+                    exit 1
+                fi
+                echo "Adding $ip for $domain"
+                ipset add allowed-domains "$ip"
+            done < <(echo "$ips")
+        fi
+    done < <(echo "$domains")
+}
+
+echo "Reading domains from configuration file: $CONFIG_FILE"
+domains=$(read_domains_from_yaml "$CONFIG_FILE")
+resolve_and_add_domains "$domains"

--- a/src/dataset_foundry/configs/agents/claude_code/firewall/allow-domains.sh
+++ b/src/dataset_foundry/configs/agents/claude_code/firewall/allow-domains.sh
@@ -12,18 +12,15 @@ fi
 
 read_domains_from_yaml() {
     local config_file="$1"
-    echo "Checking yq installed" >&2
     if ! command -v yq >/dev/null 2>&1; then
         echo "ERROR: yq is required to parse YAML files. Please install yq first." >&2
         echo "Install with: pip install yq or go install github.com/mikefarah/yq/v4@latest" >&2
         exit 1
     fi
-    echo "Checking config file exists: $config_file" >&2
     if [ ! -f "$config_file" ]; then
         echo "ERROR: YAML config file not found: $config_file" >&2
         exit 1
     fi
-    echo "Attempting to parse YAML file: $config_file" >&2
     yq -r '.allowed_domains[]' "$config_file" | grep -v '^$' | grep -v '^#'
 }
 

--- a/src/dataset_foundry/configs/agents/claude_code/firewall/firewall.yml
+++ b/src/dataset_foundry/configs/agents/claude_code/firewall/firewall.yml
@@ -1,0 +1,14 @@
+allowed_domains:
+  # Python package management
+  - pypi.org
+
+  # Node.js package management
+  - registry.npmjs.org
+
+  # Anthropic services
+  - api.anthropic.com
+  - statsig.anthropic.com
+  - statsig.com
+
+  # Monitoring and error tracking
+  - sentry.io

--- a/src/dataset_foundry/configs/agents/claude_code/firewall/init.sh
+++ b/src/dataset_foundry/configs/agents/claude_code/firewall/init.sh
@@ -1,0 +1,108 @@
+#!/bin/bash
+set -euo pipefail  # Exit on error, undefined vars, and pipeline failures
+IFS=$'\n\t'        # Stricter word splitting
+
+SCRIPT_DIR="$(cd "$(dirname "${BASH_SOURCE[0]}")" && pwd)"
+
+echo "----------------------------------------------------------------"
+echo "Configuring Firewall"
+echo "----------------------------------------------------------------"
+
+# Flush existing rules and delete existing ipsets
+echo "Fetching iptables..."
+iptables -F
+iptables -X
+iptables -t nat -F
+iptables -t nat -X
+iptables -t mangle -F
+iptables -t mangle -X
+ipset destroy allowed-domains 2>/dev/null || true
+
+# First allow DNS and localhost before any restrictions
+# Allow outbound DNS
+iptables -A OUTPUT -p udp --dport 53 -j ACCEPT
+# Allow inbound DNS responses
+iptables -A INPUT -p udp --sport 53 -j ACCEPT
+# Allow outbound SSH
+iptables -A OUTPUT -p tcp --dport 22 -j ACCEPT
+# Allow inbound SSH responses
+iptables -A INPUT -p tcp --sport 22 -m state --state ESTABLISHED -j ACCEPT
+# Allow localhost
+iptables -A INPUT -i lo -j ACCEPT
+iptables -A OUTPUT -o lo -j ACCEPT
+
+# Create ipset with CIDR support
+ipset create allowed-domains hash:net
+
+# Fetch GitHub meta information and aggregate + add their IP ranges
+echo "Fetching GitHub IP ranges..."
+gh_ranges=$(curl -s https://api.github.com/meta)
+if [ -z "$gh_ranges" ]; then
+    echo "ERROR: Failed to fetch GitHub IP ranges"
+    exit 1
+fi
+
+if ! echo "$gh_ranges" | jq -e '.web and .api and .git' >/dev/null; then
+    echo "ERROR: GitHub API response missing required fields"
+    echo "$gh_ranges"
+    exit 1
+fi
+
+echo "Processing GitHub IPs..."
+while read -r cidr; do
+    if [[ ! "$cidr" =~ ^[0-9]{1,3}\.[0-9]{1,3}\.[0-9]{1,3}\.[0-9]{1,3}/[0-9]{1,2}$ ]]; then
+        echo "ERROR: Invalid CIDR range from GitHub meta: $cidr"
+        exit 1
+    fi
+    echo "Adding GitHub range $cidr"
+    ipset add allowed-domains "$cidr"
+done < <(echo "$gh_ranges" | jq -r '(.web + .api + .git)[]' | aggregate -q)
+
+# Resolve and add other allowed domains from external configuration
+"${SCRIPT_DIR}/allow-domains.sh" "${SCRIPT_DIR}/firewall.yml"
+
+# Get host IP from default route
+HOST_IP=$(ip route | grep default | cut -d" " -f3)
+if [ -z "$HOST_IP" ]; then
+    echo "ERROR: Failed to detect host IP"
+    exit 1
+fi
+
+HOST_NETWORK=$(echo "$HOST_IP" | sed "s/\.[0-9]*$/.0\/24/")
+echo "Host network detected as: $HOST_NETWORK"
+
+# Set up remaining iptables rules
+iptables -A INPUT -s "$HOST_NETWORK" -j ACCEPT
+iptables -A OUTPUT -d "$HOST_NETWORK" -j ACCEPT
+
+# Set default policies to DROP first
+iptables -P INPUT DROP
+iptables -P FORWARD DROP
+iptables -P OUTPUT DROP
+
+# First allow established connections for already approved traffic
+iptables -A INPUT -m state --state ESTABLISHED,RELATED -j ACCEPT
+iptables -A OUTPUT -m state --state ESTABLISHED,RELATED -j ACCEPT
+
+# Then allow only specific outbound traffic to allowed domains
+iptables -A OUTPUT -m set --match-set allowed-domains dst -j ACCEPT
+
+echo "Firewall configuration complete"
+echo "Verifying firewall rules..."
+if curl --connect-timeout 5 https://example.com >/dev/null 2>&1; then
+    echo "ERROR: Firewall verification failed - was able to reach https://example.com"
+    exit 1
+else
+    echo "Firewall verification passed - unable to reach https://example.com as expected"
+fi
+
+# Verify GitHub API access
+if ! curl --connect-timeout 5 https://api.github.com/zen >/dev/null 2>&1; then
+    echo "ERROR: Firewall verification failed - unable to reach https://api.github.com"
+    exit 1
+else
+    echo "Firewall verification passed - able to reach https://api.github.com as expected"
+    echo "----------------------------------------------------------------"
+    echo "SUCCESS: Firewall configured"
+    echo "----------------------------------------------------------------"
+fi

--- a/src/dataset_foundry/configs/agents/codex/Dockerfile
+++ b/src/dataset_foundry/configs/agents/codex/Dockerfile
@@ -1,0 +1,17 @@
+FROM homebrew/ubuntu22.04
+USER root
+
+# Install system dependencies
+RUN apt-get update && \
+    apt-get install -y curl git build-essential software-properties-common && \
+    rm -rf /var/lib/apt/lists/*
+
+RUN brew install codex
+
+WORKDIR /workspace
+
+ENV LANG=en_US.UTF-8
+ENV PYTHONUNBUFFERED=1
+
+# Default command (will be overridden by entrypoint)
+CMD ["bash"]

--- a/src/dataset_foundry/configs/agents/codex/agent.yml
+++ b/src/dataset_foundry/configs/agents/codex/agent.yml
@@ -2,4 +2,4 @@ container:
   image: "codex-agent:latest"
   environment:
     OPENAI_API_KEY: "${OPENAI_API_KEY}"
-  entrypoint: ["bash", "-c", "codex exec --dangerously-bypass-approvals-and-sandbox --skip-git-repo-check \"$PROMPT\""]
+  entrypoint: ["bash", "-c", "cat input/prompt.md | codex exec --dangerously-bypass-approvals-and-sandbox --skip-git-repo-check"]

--- a/src/dataset_foundry/configs/agents/codex/agent.yml
+++ b/src/dataset_foundry/configs/agents/codex/agent.yml
@@ -2,4 +2,4 @@ container:
   image: "codex-agent:latest"
   environment:
     OPENAI_API_KEY: "${OPENAI_API_KEY}"
-  entrypoint: ["bash", "-c", "codex exec --skip-git-repo-check \"$PROMPT\""]
+  entrypoint: ["bash", "-c", "codex exec --dangerously-bypass-approvals-and-sandbox --skip-git-repo-check \"$PROMPT\""]

--- a/src/dataset_foundry/configs/agents/codex/agent.yml
+++ b/src/dataset_foundry/configs/agents/codex/agent.yml
@@ -1,0 +1,8 @@
+image: "codex-agent:latest"
+working_dir: "/workspace"
+environment:
+  OPENAI_API_KEY: "${OPENAI_API_KEY}"
+  LANG: "en_US.UTF-8"
+entrypoint: ["bash", "-c", "cat /workspace/PROMPT.md | codex exec --skip-git-repo-check"]
+build_args:
+  BUILDKIT_INLINE_CACHE: "1"

--- a/src/dataset_foundry/configs/agents/codex/agent.yml
+++ b/src/dataset_foundry/configs/agents/codex/agent.yml
@@ -1,8 +1,5 @@
-image: "codex-agent:latest"
-working_dir: "/workspace"
-environment:
-  OPENAI_API_KEY: "${OPENAI_API_KEY}"
-  LANG: "en_US.UTF-8"
-entrypoint: ["bash", "-c", "cat /workspace/PROMPT.md | codex exec --skip-git-repo-check"]
-build_args:
-  BUILDKIT_INLINE_CACHE: "1"
+container:
+  image: "codex-agent:latest"
+  environment:
+    OPENAI_API_KEY: "${OPENAI_API_KEY}"
+  entrypoint: ["bash", "-c", "codex exec --skip-git-repo-check \"$PROMPT\""]

--- a/src/dataset_foundry/configs/sandboxes/README.md
+++ b/src/dataset_foundry/configs/sandboxes/README.md
@@ -1,0 +1,114 @@
+# Sandbox Environments
+
+This directory contains sandbox configurations for running code in isolated Docker containers.
+
+## Overview
+
+Sandbox environments provide isolated, reproducible environments for running code. This is useful for:
+
+- Ensuring consistent execution environments across different machines
+- Isolating dependencies from the host system
+- Running code in controlled environments with specific versions or dependencies
+- Preventing environment pollution between different executions
+
+## Available Sandboxes
+
+### Python Sandbox (`python`)
+
+A Python 3.11 environment with common development dependencies.
+
+**Features:**
+- Python 3.11-slim base image
+- pytest, pytest-cov, pytest-mock installed for testing
+- Non-root user for security
+
+**Configuration:**
+- Image: `python-sandbox:latest`
+- Working directory: `/workspace`
+- Default command: `python`
+
+## Usage
+
+### In Pipeline Actions
+
+```python
+from dataset_foundry.actions.item.run_unit_tests import run_unit_tests
+
+# Run unit tests in sandbox
+run_unit_tests(
+    filename="test.py",
+    sandbox="python",  # Use the python sandbox
+    timeout=600,  # 10 minute timeout
+    stream_logs=True,  # Stream container logs
+    property="test_result"
+)
+```
+
+### Direct Sandbox Usage
+
+```python
+from dataset_foundry.utils.docker.sandbox_runner import SandboxRunner
+
+# Run arbitrary Python code in sandbox
+sandbox_runner = SandboxRunner("python")
+
+result = await sandbox_runner.run(
+    target_file=Path("script.py"),
+    workspace_dir=Path("workspace"),
+    command=["python", "script.py"],
+    timeout=300,
+    stream_logs=True
+)
+```
+
+### Parameters
+
+- `sandbox`: Name of the sandbox configuration within `configs/sandboxes`
+- `timeout`: Timeout for execution in seconds (default: 300)
+- `stream_logs`: Whether to stream container logs to console
+- `property`: Property name to store results
+
+## Creating Custom Sandboxes
+
+To create a custom sandbox:
+
+1. Create a new directory under `configs/sandboxes/`
+2. Add a `Dockerfile` for the sandbox environment
+3. Add a `sandbox.yml` configuration file
+4. Optionally add additional files (requirements.txt, etc.)
+
+## How It Works
+
+1. **Image Building**: The sandbox Docker image is built if it doesn't exist
+2. **Container Execution**: A container is started with the workspace directory mounted as a volume
+3. **Code Execution**: Code is executed inside the container using the specified command
+4. **Result Parsing**: Container output is parsed into `SandboxResult` format
+5. **Cleanup**: The container is automatically removed after execution
+
+## Security Considerations
+
+- Sandboxes run as non-root users when possible
+- Containers are automatically removed after execution
+- Temporary workspaces are cleaned up after use
+- Network access can be restricted if needed
+
+## Troubleshooting
+
+### Common Issues
+
+1. **Docker not running**: Ensure Docker daemon is running
+2. **Image build failures**: Check Dockerfile syntax and dependencies
+3. **Permission issues**: Ensure Docker has access to the workspace directory
+4. **Timeout issues**: Increase timeout in sandbox configuration
+
+### Debugging
+
+Enable `stream_logs=True` to see container output in real-time:
+
+```python
+run_unit_tests(
+    filename="test.py",
+    sandbox="python",
+    stream_logs=True
+)
+```

--- a/src/dataset_foundry/configs/sandboxes/python/Dockerfile
+++ b/src/dataset_foundry/configs/sandboxes/python/Dockerfile
@@ -7,6 +7,7 @@ ENV PYTHONDONTWRITEBYTECODE="1"
 # Install system dependencies
 RUN apt-get update && apt-get install -y \
     git \
+    gcc \
     && rm -rf /var/lib/apt/lists/*
 
 # Set working directory

--- a/src/dataset_foundry/configs/sandboxes/python/Dockerfile
+++ b/src/dataset_foundry/configs/sandboxes/python/Dockerfile
@@ -12,6 +12,9 @@ RUN apt-get update && apt-get install -y \
 # Set working directory
 WORKDIR /workspace
 
+# Quiet warning about new pip release
+RUN pip install --upgrade pip
+
 # Install Python testing dependencies
 RUN pip install --no-cache-dir \
     pytest \

--- a/src/dataset_foundry/configs/sandboxes/python/Dockerfile
+++ b/src/dataset_foundry/configs/sandboxes/python/Dockerfile
@@ -1,5 +1,9 @@
 FROM python:3.11-slim
 
+# Avoid buffering stdout and stderr and disable creating `__pycache__` directories
+ENV PYTHONUNBUFFERED="1"
+ENV PYTHONDONTWRITEBYTECODE="1"
+
 # Install system dependencies
 RUN apt-get update && apt-get install -y \
     git \

--- a/src/dataset_foundry/configs/sandboxes/python/Dockerfile
+++ b/src/dataset_foundry/configs/sandboxes/python/Dockerfile
@@ -21,6 +21,9 @@ RUN useradd --create-home --shell /bin/bash guest
 COPY init.sh /usr/local/bin/init.sh
 RUN chmod +x /usr/local/bin/init.sh
 
+# Change ownership of workspace directory to guest user
+RUN chown -R guest:guest /workspace
+
 USER guest
 
 # Install dependencies, if needed

--- a/src/dataset_foundry/configs/sandboxes/python/Dockerfile
+++ b/src/dataset_foundry/configs/sandboxes/python/Dockerfile
@@ -16,7 +16,15 @@ RUN pip install --no-cache-dir \
 
 # Create a non-root user for security
 RUN useradd --create-home --shell /bin/bash guest
+
+# Copy the init script
+COPY init.sh /usr/local/bin/init.sh
+RUN chmod +x /usr/local/bin/init.sh
+
 USER guest
+
+# Install dependencies, if needed
+ENTRYPOINT ["sh", "-c", "/usr/local/bin/init.sh && bash -c \"$*\"", "--"]
 
 # Default command (can be overridden)
 CMD ["python"]

--- a/src/dataset_foundry/configs/sandboxes/python/Dockerfile
+++ b/src/dataset_foundry/configs/sandboxes/python/Dockerfile
@@ -1,0 +1,22 @@
+FROM python:3.11-slim
+
+# Install system dependencies
+RUN apt-get update && apt-get install -y \
+    git \
+    && rm -rf /var/lib/apt/lists/*
+
+# Set working directory
+WORKDIR /workspace
+
+# Install Python testing dependencies
+RUN pip install --no-cache-dir \
+    pytest \
+    pytest-cov \
+    pytest-mock
+
+# Create a non-root user for security
+RUN useradd --create-home --shell /bin/bash guest
+USER guest
+
+# Default command (can be overridden)
+CMD ["python"]

--- a/src/dataset_foundry/configs/sandboxes/python/init.sh
+++ b/src/dataset_foundry/configs/sandboxes/python/init.sh
@@ -1,0 +1,12 @@
+#!/bin/bash
+# Add local bin directory to PATH to quiet pip warning
+export PATH="$HOME/.local/bin:$PATH"
+
+# Install requirements.txt if it exists in the current working directory
+if [ -f "requirements.txt" ]; then
+    echo "Installing dependencies from requirements.txt..."
+    pip install --user -r requirements.txt
+    echo "Dependencies installed successfully."
+else
+    echo "No requirements.txt found in working directory, skipping dependency installation."
+fi

--- a/src/dataset_foundry/configs/sandboxes/python/sandbox.yml
+++ b/src/dataset_foundry/configs/sandboxes/python/sandbox.yml
@@ -1,4 +1,4 @@
-name: python-sandbox2
+name: python-sandbox
 container:
   image: python-sandbox:latest
   build:

--- a/src/dataset_foundry/configs/sandboxes/python/sandbox.yml
+++ b/src/dataset_foundry/configs/sandboxes/python/sandbox.yml
@@ -1,0 +1,8 @@
+name: python-sandbox2
+container:
+  image: python-sandbox:latest
+  build:
+    context: .
+    dockerfile: Dockerfile
+  working_dir: /workspace
+  command: ["python"]

--- a/src/dataset_foundry/core/config.py
+++ b/src/dataset_foundry/core/config.py
@@ -1,4 +1,4 @@
-import json
+import datason.json as json
 from pathlib import Path
 import yaml
 

--- a/src/dataset_foundry/utils/docker/agent_runner.py
+++ b/src/dataset_foundry/utils/docker/agent_runner.py
@@ -64,7 +64,7 @@ class AgentRunner(BaseRunner):
         """
         super().__init__(agent_type, "agents", "agent.yml", container_manager)
 
-    async def run_agent(
+    async def run(
         self,
         inputs: AgentInputs,
         output_dir: Path,

--- a/src/dataset_foundry/utils/docker/agent_runner.py
+++ b/src/dataset_foundry/utils/docker/agent_runner.py
@@ -27,8 +27,8 @@ class AgentConfig(BaseModel):
 
 class AgentInputs(BaseModel):
     """Input files for agent execution."""
+    prompt: str
     instructions_file: str
-    prompt_file: str
     spec_file: str
     output_dir: str
     item_id: str
@@ -220,12 +220,6 @@ class AgentRunner:
                 read_only=True
             ),
             Mount(
-                target=f"{inputs_dir}/PROMPT.md",
-                source=str(inputs.prompt_file),
-                type="bind",
-                read_only=True
-            ),
-            Mount(
                 target=f"{inputs_dir}/spec.yaml",
                 source=str(inputs.spec_file),
                 type="bind",
@@ -240,6 +234,7 @@ class AgentRunner:
             "ITEM_ID": inputs.item_id,
             "OUTPUT_DIR": f"{working_dir}/output",
             "CONTEXT_DATA": json.dumps(inputs.context_data),
+            "PROMPT": inputs.prompt,
         })
 
         config.environment = resolve_environment_dict(config.environment)

--- a/src/dataset_foundry/utils/docker/agent_runner.py
+++ b/src/dataset_foundry/utils/docker/agent_runner.py
@@ -3,8 +3,6 @@ Agent runner for executing different types of agents in containers.
 """
 
 import logging
-import json
-import yaml
 from copy import deepcopy
 from pathlib import Path
 from typing import Dict, Any, Optional, List

--- a/src/dataset_foundry/utils/docker/agent_runner.py
+++ b/src/dataset_foundry/utils/docker/agent_runner.py
@@ -133,7 +133,7 @@ class AgentRunner:
     async def _ensure_image_built(self, stream_logs: bool = False):
         """Ensure the agent's Docker image is built."""
 
-        config = deepcopy(self._config.container.build)
+        config = deepcopy(self._config.container.build or BuildConfig())
         agent_config_dir = agent_configs_dir / self._config.name
 
         if not config.context:

--- a/src/dataset_foundry/utils/docker/agent_runner.py
+++ b/src/dataset_foundry/utils/docker/agent_runner.py
@@ -120,8 +120,18 @@ class AgentRunner(BaseRunner):
         working_dir = self._get_working_dir(config)
         inputs_dir = Path(working_dir) / "input"
 
+        # Write prompt to a file to avoid issues when the prompt is too long
+        prompt_file = output_dir / "input" / "prompt.md"
+        prompt_file.write_text(inputs.prompt)
+
         self._prepare_volumes_config(config, [
             Mount(target=working_dir, source=str(output_dir), type="bind", read_only=False),
+            Mount(
+                target=f"{inputs_dir}/prompt.md",
+                source=str(prompt_file),
+                type="bind",
+                read_only=True
+            ),
             Mount(
                 target=f"{inputs_dir}/AGENTS.md",
                 source=str(inputs.instructions_file),
@@ -139,7 +149,6 @@ class AgentRunner(BaseRunner):
             "ITEM_ID": inputs.item_id,
             "OUTPUT_DIR": f"{working_dir}/output",
             "CONTEXT_DATA": json.dumps(inputs.context_data),
-            "PROMPT": inputs.prompt,
         })
 
         return config

--- a/src/dataset_foundry/utils/docker/agent_runner.py
+++ b/src/dataset_foundry/utils/docker/agent_runner.py
@@ -8,7 +8,7 @@ import yaml
 import os
 from pathlib import Path
 from typing import Dict, Any, Optional, List
-from dataclasses import dataclass
+from pydantic import BaseModel
 
 from .container_manager import ContainerManager, ContainerConfig, ContainerResult
 
@@ -16,8 +16,7 @@ logger = logging.getLogger(__name__)
 agent_configs_dir = Path(__file__).parent.parent.parent / "configs" / "agents"
 
 
-@dataclass
-class AgentConfig:
+class AgentConfig(BaseModel):
     """Configuration for an agent type."""
     name: str
     image: str
@@ -28,8 +27,7 @@ class AgentConfig:
     build_args: Optional[Dict[str, str]] = None
 
 
-@dataclass
-class AgentInputs:
+class AgentInputs(BaseModel):
     """Input files for agent execution."""
     instructions_file: str
     prompt_file: str
@@ -40,8 +38,7 @@ class AgentInputs:
     repo_path: Optional[str] = None
 
 
-@dataclass
-class AgentResult:
+class AgentResult(BaseModel):
     """Result from agent execution."""
     success: bool
     exit_code: int

--- a/src/dataset_foundry/utils/docker/agent_runner.py
+++ b/src/dataset_foundry/utils/docker/agent_runner.py
@@ -2,6 +2,7 @@
 Agent runner for executing different types of agents in containers.
 """
 
+import datason.json as json
 import logging
 from copy import deepcopy
 from pathlib import Path

--- a/src/dataset_foundry/utils/docker/agent_runner.py
+++ b/src/dataset_foundry/utils/docker/agent_runner.py
@@ -131,13 +131,9 @@ class AgentRunner:
 
     async def _ensure_image_built(self, stream_logs: bool = False):
         """Ensure the agent's Docker image is built."""
-        try:
-            # Check if image exists
-            self.container_manager.docker_client.images.get(self._config.image)
-            logger.info(f"Image {self._config.image} already exists")
+        if self.container_manager.image_exists(self._config.container.image):
+            logger.info(f"Image {self._config.container.image} already exists")
             return
-        except:
-            pass
 
         dockerfile_path = agent_configs_dir / self._config.name
         if dockerfile_path and dockerfile_path.exists():

--- a/src/dataset_foundry/utils/docker/agent_runner.py
+++ b/src/dataset_foundry/utils/docker/agent_runner.py
@@ -12,23 +12,14 @@ from typing import Dict, Any, Optional, List
 from docker.types import Mount
 from pydantic import BaseModel
 
-from .container_manager import BuildConfig, ContainerManager, ContainerConfig, ContainerResult
-from ..params.resolve_environment_dict import resolve_environment_dict
+from .base_runner import BaseRunner, RunnerConfig
+from .container_manager import ContainerConfig, ContainerManager, ContainerResult
 
 logger = logging.getLogger(__name__)
-agent_configs_dir = Path(__file__).parent.parent.parent / "configs" / "agents"
 
 
-class AgentLogsConfig(BaseModel):
-    """Configuration for agent logs."""
-    format: Optional[str] = None
-
-
-class AgentConfig(BaseModel):
-    """Configuration for an agent type."""
-    name: str
-    container: ContainerConfig
-    logs: Optional[AgentLogsConfig] = None
+class AgentConfig(RunnerConfig):
+    """Configuration for an agent runner."""
 
 
 class AgentInputs(BaseModel):
@@ -54,7 +45,7 @@ class AgentResult(BaseModel):
     stderr: str
 
 
-class AgentRunner:
+class AgentRunner(BaseRunner):
     """Runs different types of agents in Docker containers."""
 
     _config: Optional[AgentConfig] = None
@@ -71,9 +62,7 @@ class AgentRunner:
             agent_type: Type of agent to run
             container_manager: Optional container manager instance
         """
-        self.agent_type = agent_type
-        self.container_manager = container_manager or ContainerManager()
-        self._config: Optional[AgentConfig] = None
+        super().__init__(agent_type, "agents", "agent.yml", container_manager)
 
     async def run_agent(
         self,
@@ -104,102 +93,22 @@ class AgentRunner:
 
             container_config = self._prepare_container_config(inputs, output_dir)
 
-            logger.info(f"Running agent {self.agent_type} (attempt {attempt})")
+            logger.info(f"Running agent {self.runner_name} (attempt {attempt})")
             container_result = await self.container_manager.run_container(
                 container_config,
                 timeout=timeout,
                 stream_logs=stream_logs,
-                logs_format=self._config.logs.format
+                logs_format=self._config.logs.format if self._config.logs else None
             )
 
             result = self._process_container_result(container_result, inputs, output_dir)
 
-            logger.info(f"Agent {self.agent_type} completed with exit code {result.exit_code}")
+            logger.info(f"Agent {self.runner_name} completed with exit code {result.exit_code}")
             return result
 
         except Exception as e:
             logger.error(f"Agent execution failed: {e}")
             raise
-
-    async def _load_config(self) -> AgentConfig:
-        """Load agent-specific configuration from configs/agents/{agent_name}/agent.yml."""
-        agent_config_path = agent_configs_dir / self.agent_type / "agent.yml"
-
-        if agent_config_path.exists():
-            with open(agent_config_path, 'r') as f:
-                config_data = yaml.safe_load(f)
-
-            logger.info(f"Loaded agent configuration from {agent_config_path}")
-
-            return AgentConfig(
-                name=self.agent_type,
-                container=ContainerConfig(**config_data['container']),
-                logs=AgentLogsConfig(**config_data.get('logs', {})),
-            )
-        else:
-            raise ValueError(
-                f"Unknown agent type: {self.agent_type}: "
-                f"No agent configuration found at {agent_config_path}"
-            )
-
-    async def _ensure_image_built(self, stream_logs: bool = False):
-        """Ensure the agent's Docker image is built."""
-
-        config = deepcopy(self._config.container.build or BuildConfig())
-        agent_config_dir = agent_configs_dir / self._config.name
-
-        if not config.context:
-            config.context = agent_config_dir
-        elif not Path(config.context).is_absolute():
-            config.context = agent_config_dir / config.context
-
-        config.args = resolve_environment_dict(config.args)
-        build_required = self._image_build_required(config) # requires resolved `config`
-
-        # `build_required` can only be false if the image exists
-        if not build_required:
-            logger.info(f"Image {self._config.container.image} already exists")
-            return
-
-        if config.context and Path(config.context).exists():
-            await self.container_manager.build_image(
-                image_name=self._config.container.image,
-                config=config,
-                stream_logs=stream_logs
-            )
-        else:
-            raise ValueError(f"No context found for agent {self._config.name} at {config.context}")
-
-    def _image_build_required(self, build_config: BuildConfig) -> bool:
-        try:
-            image_name = self._config.container.image
-            last_built = self.container_manager.get_image_last_built(image_name)
-
-            if last_built is None:
-                return True
-
-            dockerfile_mtime = self._get_dockerfile_last_modified(build_config)
-
-            if not dockerfile_mtime or dockerfile_mtime > last_built:
-                return True
-
-            # TODO: If agents.yaml has `build` section that has been modified since last build,
-            #       then also we need to rebuild the image. [fastfedora 22.Jul.25]
-
-            return False
-        except Exception as e:
-            return True
-
-    def _get_dockerfile_last_modified(self, build_config: BuildConfig) -> Optional[float]:
-        """Get the last modified time of the Dockerfile."""
-        dockerfile_path = build_config.dockerfile or "Dockerfile"
-
-        if not Path(dockerfile_path).exists():
-            dockerfile_path = build_config.context / dockerfile_path
-
-        dockerfile = Path(dockerfile_path)
-
-        return dockerfile.stat().st_mtime if dockerfile.exists() else None
 
     def _prepare_container_config(
         self,
@@ -209,22 +118,10 @@ class AgentRunner:
         """Prepare container configuration for agent execution."""
 
         config = deepcopy(self._config.container)
-        image_config = self.container_manager.get_image_config(self._config.container.image)
-        working_dir = config.working_dir or image_config.get("WorkingDir")
-
-        if not working_dir:
-            raise ValueError(f"No working directory configured for {self.agent_type}")
-
+        working_dir = self._get_working_dir(config)
         inputs_dir = Path(working_dir) / "input"
 
-        if not config.volumes:
-            config.volumes = []
-        else:
-            for volume in config.volumes:
-                if not Path(volume['Source']).is_absolute():
-                    volume['Source'] = str(output_dir / volume['Source'])
-
-        config.volumes.extend([
+        self._prepare_volumes_config(config, [
             Mount(target=working_dir, source=str(output_dir), type="bind", read_only=False),
             Mount(
                 target=f"{inputs_dir}/AGENTS.md",
@@ -239,18 +136,12 @@ class AgentRunner:
                 read_only=True
             ),
         ])
-
-        if not config.environment:
-            config.environment = {}
-
-        config.environment.update({
+        self._prepare_environment_config(config, {
             "ITEM_ID": inputs.item_id,
             "OUTPUT_DIR": f"{working_dir}/output",
             "CONTEXT_DATA": json.dumps(inputs.context_data),
             "PROMPT": inputs.prompt,
         })
-
-        config.environment = resolve_environment_dict(config.environment)
 
         return config
 
@@ -270,7 +161,7 @@ class AgentRunner:
                     repo_files.append(str(file_path.relative_to(repo_dir)))
 
         metadata = {
-            "agent_type": self.agent_type,
+            "agent_type": self.runner_name,
             "container_id": container_result.container_id,
             "repo_dir": str(repo_dir),
         }

--- a/src/dataset_foundry/utils/docker/agent_runner.py
+++ b/src/dataset_foundry/utils/docker/agent_runner.py
@@ -1,0 +1,241 @@
+"""
+Agent runner for executing different types of agents in containers.
+"""
+
+import logging
+import json
+import yaml
+import os
+from pathlib import Path
+from typing import Dict, Any, Optional, List
+from dataclasses import dataclass
+
+from .container_manager import ContainerManager, ContainerConfig, ContainerResult
+
+logger = logging.getLogger(__name__)
+agent_configs_dir = Path(__file__).parent.parent.parent / "configs" / "agents"
+
+
+@dataclass
+class AgentConfig:
+    """Configuration for an agent type."""
+    name: str
+    image: str
+    entrypoint: Optional[List[str]] = None
+    working_dir: str = "/workspace"
+    environment: Optional[Dict[str, str]] = None
+    volumes: Optional[Dict[str, Dict[str, str]]] = None
+    build_args: Optional[Dict[str, str]] = None
+
+
+@dataclass
+class AgentInputs:
+    """Input files for agent execution."""
+    instructions_file: str
+    prompt_file: str
+    spec_file: str
+    output_dir: str
+    item_id: str
+    context_data: Dict[str, Any]
+    repo_path: Optional[str] = None
+
+
+@dataclass
+class AgentResult:
+    """Result from agent execution."""
+    success: bool
+    exit_code: int
+    output_files: List[str]
+    logs: str
+    metadata: Dict[str, Any]
+
+
+class AgentRunner:
+    """Runs different types of agents in Docker containers."""
+
+    def __init__(
+        self,
+        agent_type: str,
+        container_manager: Optional[ContainerManager] = None
+    ):
+        """
+        Initialize the agent runner.
+
+        Args:
+            agent_type: Type of agent to run
+            container_manager: Optional container manager instance
+        """
+        self.agent_type = agent_type
+        self.container_manager = container_manager or ContainerManager()
+        self._config: Optional[AgentConfig] = None
+
+    async def run_agent(
+        self,
+        inputs: AgentInputs,
+        output_dir: Path,
+        timeout: int = 3600,
+        attempt: int = 1,
+        stream_logs: bool = False
+    ) -> AgentResult:
+        """
+        Run an agent with the given inputs.
+
+        Args:
+            inputs: Agent input files and data
+            output_dir: Directory for agent output
+            timeout: Execution timeout in seconds
+            attempt: Current attempt number
+            stream_logs: Whether to stream container logs to logger.info (default: False)
+
+        Returns:
+            AgentResult with execution details
+        """
+        try:
+            if self._config is None:
+                self._config = await self._load_config()
+
+            await self._ensure_image_built(stream_logs)
+
+            container_config = self._prepare_container_config(inputs, output_dir)
+
+            logger.info(f"Running agent {self.agent_type} (attempt {attempt})")
+            container_result = await self.container_manager.run_container(
+                container_config, timeout=timeout, stream_logs=stream_logs
+            )
+
+            result = self._process_container_result(container_result, output_dir, inputs.item_id)
+
+            logger.info(f"Agent {self.agent_type} completed with exit code {result.exit_code}")
+            return result
+
+        except Exception as e:
+            logger.error(f"Agent execution failed: {e}")
+            raise
+
+    async def _load_config(self) -> AgentConfig:
+        """Load agent-specific configuration from configs/agents/{agent_name}/agent.yml."""
+        agent_config_path = agent_configs_dir / self.agent_type / "agent.yml"
+
+        if agent_config_path.exists():
+            with open(agent_config_path, 'r') as f:
+                config_data = yaml.safe_load(f)
+
+            logger.info(f"Loaded agent configuration from {agent_config_path}")
+
+            return AgentConfig(
+                **config_data,
+                name=self.agent_type,
+            )
+        else:
+            raise ValueError(
+                f"Unknown agent type: {self.agent_type}: "
+                f"No agent configuration found at {agent_config_path}"
+            )
+
+    async def _ensure_image_built(self, stream_logs: bool = False):
+        """Ensure the agent's Docker image is built."""
+        try:
+            # Check if image exists
+            self.container_manager.docker_client.images.get(self._config.image)
+            logger.info(f"Image {self._config.image} already exists")
+            return
+        except:
+            pass
+
+        dockerfile_path = agent_configs_dir / self._config.name
+        if dockerfile_path and dockerfile_path.exists():
+            await self.container_manager.build_image(
+                dockerfile_path=dockerfile_path,
+                image_name=self._config.image,
+                build_args=self._config.build_args,
+                stream_logs=stream_logs
+            )
+        else:
+            raise ValueError(f"No Dockerfile found for agent {self._config.name}")
+
+    def _prepare_container_config(
+        self,
+        inputs: AgentInputs,
+        output_dir: Path
+    ) -> ContainerConfig:
+        """Prepare container configuration for agent execution."""
+
+        volumes = {
+            str(output_dir): {"bind": "/workspace", "mode": "rw"},
+            inputs.instructions_file: {"bind": "/workspace/AGENTS.md", "mode": "ro"},
+            inputs.prompt_file: {"bind": "/workspace/PROMPT.md", "mode": "ro"},
+            inputs.spec_file: {"bind": "/workspace/spec.yaml", "mode": "ro"},
+        }
+
+        # Add agent-specific volumes
+        if self._config.volumes:
+            volumes.update(self._config.volumes)
+
+        environment = {
+            "ITEM_ID": inputs.item_id,
+            "OUTPUT_DIR": "/workspace/repo",
+            "CONTEXT_DATA": json.dumps(inputs.context_data),
+        }
+
+        if self._config.environment:
+            # Handle environment variable substitution
+            for key, value in self._config.environment.items():
+                if isinstance(value, str) and value.startswith("${") and value.endswith("}"):
+                    # Extract variable name and get from system environment
+                    var_name = value[2:-1]  # Remove ${ and }
+                    system_value = os.environ.get(var_name)
+                    if system_value:
+                        environment[key] = system_value
+                    else:
+                        logger.warning(f"Environment variable {var_name} not found")
+                else:
+                    environment[key] = value
+
+        command = self._config.entrypoint or [
+            "python", "-m", "agent.main",
+            "--instructions", "/workspace/AGENTS.md",
+            "--prompt", "/workspace/PROMPT.md",
+            "--spec", "/workspace/spec.yaml",
+            "--repo-dir", "/workspace/repo"
+        ]
+
+        return ContainerConfig(
+            image=self._config.image,
+            command=command,
+            environment=environment,
+            volumes=volumes,
+            working_dir=self._config.working_dir,
+            remove=True,
+            timeout=3600
+        )
+
+    def _process_container_result(
+        self,
+        container_result: ContainerResult,
+        output_dir: Path,
+        item_id: str
+    ) -> AgentResult:
+        """Process container execution result."""
+
+        repo_dir = output_dir / "repo"
+        repo_files = []
+        if repo_dir.exists():
+            for file_path in repo_dir.rglob("*"):
+                if file_path.is_file() and not file_path.name.startswith("."):
+                    repo_files.append(str(file_path.relative_to(repo_dir)))
+
+        metadata = {
+            "container_id": container_result.container_id,
+            "exit_code": container_result.exit_code,
+            "output_files": repo_files,
+            "item_id": item_id,
+            "agent_type": self.agent_type,
+        }
+
+        return AgentResult(
+            success=container_result.exit_code == 0,
+            exit_code=container_result.exit_code,
+            output_files=repo_files,
+            logs=container_result.logs,
+            metadata=metadata
+        )

--- a/src/dataset_foundry/utils/docker/agent_runner.py
+++ b/src/dataset_foundry/utils/docker/agent_runner.py
@@ -50,6 +50,8 @@ class AgentResult(BaseModel):
     exit_code: int
     output_files: List[str]
     logs: str
+    stdout: str
+    stderr: str
 
 
 class AgentRunner:
@@ -280,4 +282,6 @@ class AgentRunner:
             exit_code=container_result.exit_code,
             output_files=repo_files,
             logs=container_result.logs,
+            stdout=container_result.stdout,
+            stderr=container_result.stderr,
         )

--- a/src/dataset_foundry/utils/docker/base_runner.py
+++ b/src/dataset_foundry/utils/docker/base_runner.py
@@ -1,0 +1,193 @@
+"""
+Base container runner for managing running commands within Docker containers.
+"""
+
+import logging
+from copy import deepcopy
+from pathlib import Path
+from typing import Any, Dict, List, Optional
+
+from docker.types import Mount
+from pydantic import BaseModel
+import yaml
+
+from ..params.resolve_environment_dict import resolve_environment_dict
+from .container_manager import BuildConfig, ContainerConfig, ContainerManager
+
+logger = logging.getLogger(__name__)
+base_configs_dir = Path(__file__).parent.parent.parent / "configs"
+
+
+class LogsConfig(BaseModel):
+    """Configuration for container logs."""
+    format: Optional[str] = None
+
+
+class RunnerConfig(BaseModel):
+    """Base configuration for container runners."""
+    container: ContainerConfig
+    logs: Optional[LogsConfig] = None
+
+
+class BaseRunner:
+    """Base class for container-based runners."""
+
+    _config: Optional[RunnerConfig] = None
+
+    def __init__(
+        self,
+        runner_name: str,
+        configs_dir: str,
+        config_filename: str,
+        container_manager: Optional[ContainerManager] = None
+    ):
+        """
+        Initialize the base container runner.
+
+        Args:
+            runner_name: Name of the runner configuration
+            configs_dir: Directory where the configurations for runners are stored, either absolute
+                or relative to the `src/configs` directory.
+            config_filename: Name of the configuration file for this runner.
+            container_manager: Optional container manager instance
+        """
+        self.runner_name = runner_name
+        self.configs_dir = configs_dir
+        self.config_filename = config_filename
+        self.container_manager = container_manager or ContainerManager()
+        self._config: Optional[RunnerConfig] = None
+
+    def _get_config_path(self) -> Path:
+        """Get the path to the runner configuration files."""
+        if not Path(self.configs_dir).is_absolute():
+            return base_configs_dir / self.configs_dir / self.runner_name
+        else:
+            return Path(self.configs_dir) / self.runner_name
+
+    def _parse_config(self, config_data: dict) -> RunnerConfig:
+        """Parse the configuration data into a RunnerConfig object."""
+        return RunnerConfig(
+            name=self.runner_name,
+            container=ContainerConfig(**config_data['container']),
+            logs=LogsConfig(**config_data.get('logs', {})),
+        )
+
+    async def _load_config(self) -> RunnerConfig:
+        """Load configuration from YAML file."""
+        config_path = self._get_config_path() / self.config_filename
+
+        if config_path.exists():
+            with open(config_path, 'r') as f:
+                config_data = yaml.safe_load(f)
+
+            logger.info(f"Loaded agent configuration from {config_path}")
+
+            return self._parse_config(config_data)
+        else:
+            raise ValueError(
+                f"Unknown runner type: {self.runner_name}: "
+                f"No configuration found at {config_path}"
+            )
+
+    async def _ensure_image_built(self, stream_logs: bool = False):
+        """Ensure the container's Docker image is built."""
+        if self._config is None:
+            self._config = await self._load_config()
+
+        config = deepcopy(self._config.container.build or BuildConfig())
+        runner_config_dir = self._get_config_path()
+
+        if not config.context:
+            config.context = runner_config_dir
+        elif not Path(config.context).is_absolute():
+            config.context = runner_config_dir / config.context
+
+        config.args = resolve_environment_dict(config.args)
+        build_required = self._image_build_required(config)
+
+        # `build_required` can only be false if the image exists
+        if not build_required:
+            logger.info(f"Image {self._config.container.image} already exists")
+            return
+
+        if config.context and Path(config.context).exists():
+            await self.container_manager.build_image(
+                image_name=self._config.container.image,
+                config=config,
+                stream_logs=stream_logs
+            )
+        else:
+            raise ValueError(f"No context found for {self.runner_name} at {config.context}")
+
+    def _image_build_required(self, build_config: BuildConfig) -> bool:
+        """Check if the image needs to be rebuilt."""
+        try:
+            image_name = self._config.container.image
+            last_built = self.container_manager.get_image_last_built(image_name)
+
+            if last_built is None:
+                return True
+
+            dockerfile_mtime = self._get_dockerfile_last_modified(build_config)
+
+            if not dockerfile_mtime or dockerfile_mtime > last_built:
+                return True
+
+            return False
+        except Exception as e:
+            return True
+
+    def _get_dockerfile_last_modified(self, build_config: BuildConfig) -> Optional[float]:
+        """Get the last modified time of the Dockerfile."""
+        dockerfile_path = build_config.dockerfile or "Dockerfile"
+
+        if not Path(dockerfile_path).exists():
+            dockerfile_path = build_config.context / dockerfile_path
+
+        dockerfile = Path(dockerfile_path)
+
+        return dockerfile.stat().st_mtime if dockerfile.exists() else None
+
+    def _get_working_dir(self, config: ContainerConfig) -> str:
+        """Get the working directory for the container."""
+        image_config = self.container_manager.get_image_config(config.image)
+        working_dir = config.working_dir or image_config.get("WorkingDir")
+
+        if not working_dir:
+            raise ValueError(f"No working directory configured for {self.runner_name}")
+
+        return working_dir
+
+    def _prepare_volumes_config(
+        self,
+        config: ContainerConfig,
+        volumes: List[Mount],
+        output_dir: Optional[Path] = None
+    ) -> None:
+        """Configure volumes for the container."""
+        if not config.volumes:
+            config.volumes = []
+        else:
+            for volume in config.volumes:
+                if not Path(volume['Source']).is_absolute():
+                    if output_dir:
+                        volume['Source'] = str(output_dir / volume['Source'])
+                    else:
+                        raise ValueError(f"No output directory configured for {self.runner_name}")
+
+        if volumes:
+            config.volumes.extend(volumes)
+
+    def _prepare_environment_config(
+        self,
+        config: ContainerConfig,
+        environment: Optional[Dict[str, Any]] = None
+    ) -> None:
+        """Prepare environment configuration for the container."""
+        if not config.environment:
+            config.environment = {}
+
+        if environment:
+            config.environment.update(environment)
+
+        config.environment = resolve_environment_dict(config.environment)

--- a/src/dataset_foundry/utils/docker/base_runner.py
+++ b/src/dataset_foundry/utils/docker/base_runner.py
@@ -80,7 +80,7 @@ class BaseRunner:
             with open(config_path, 'r') as f:
                 config_data = yaml.safe_load(f)
 
-            logger.info(f"Loaded agent configuration from {config_path}")
+            logger.info(f"Loaded configuration from {config_path}")
 
             return self._parse_config(config_data)
         else:

--- a/src/dataset_foundry/utils/docker/container_manager.py
+++ b/src/dataset_foundry/utils/docker/container_manager.py
@@ -6,15 +6,14 @@ import asyncio
 import logging
 from pathlib import Path
 from typing import Dict, List, Optional
-from dataclasses import dataclass
 import docker
 from docker.errors import DockerException
+from pydantic import BaseModel, model_validator
 
 logger = logging.getLogger(__name__)
 
 
-@dataclass
-class ContainerConfig:
+class ContainerConfig(BaseModel):
     """Configuration for a Docker container."""
     image: str
     command: Optional[List[str]] = None
@@ -26,8 +25,7 @@ class ContainerConfig:
     timeout: int = 3600
 
 
-@dataclass
-class ContainerResult:
+class ContainerResult(BaseModel):
     """Result from container execution."""
     exit_code: int
     stdout: str

--- a/src/dataset_foundry/utils/docker/container_manager.py
+++ b/src/dataset_foundry/utils/docker/container_manager.py
@@ -4,6 +4,7 @@ Container manager for orchestrating Docker containers.
 
 import asyncio
 import logging
+from datetime import datetime
 from pathlib import Path
 from typing import Dict, List, Optional, Union, Any
 
@@ -163,6 +164,15 @@ class ContainerManager:
             return True
         except:
             return False
+
+    def get_image_last_built(self, image_name: str) -> Optional[float]:
+        """Get the configuration of a Docker image."""
+        try:
+            last_built = self._docker_client.images.get(image_name).attrs['Created']
+
+            return datetime.fromisoformat(last_built.replace('Z', '+00:00')).timestamp()
+        except Exception as e:
+            return None
 
     def get_image_config(self, image_name: str) -> Any:
         """Get the configuration of a Docker image."""

--- a/src/dataset_foundry/utils/docker/container_manager.py
+++ b/src/dataset_foundry/utils/docker/container_manager.py
@@ -4,7 +4,7 @@ Container manager for orchestrating Docker containers.
 
 import asyncio
 import logging
-import json
+import datason.json as json
 from datetime import datetime
 from pathlib import Path
 from typing import Dict, List, Optional, Union, Any

--- a/src/dataset_foundry/utils/docker/container_manager.py
+++ b/src/dataset_foundry/utils/docker/container_manager.py
@@ -168,7 +168,10 @@ class ContainerManager:
     def get_image_last_built(self, image_name: str) -> Optional[float]:
         """Get the configuration of a Docker image."""
         try:
-            last_built = self._docker_client.images.get(image_name).attrs['Created']
+            created = self._docker_client.images.get(image_name).attrs['Created']
+            metadata = self._docker_client.images.get(image_name).attrs['Metadata']
+            last_tag_time = metadata['LastTagTime'] if metadata else None
+            last_built = last_tag_time or created
 
             return datetime.fromisoformat(last_built.replace('Z', '+00:00')).timestamp()
         except Exception as e:
@@ -343,6 +346,7 @@ class ContainerManager:
                 logs='\n'.join(logs),
                 container_id=container.id
             )
+
         except Exception as e:
             logger.error(f"Error waiting for container {container.id}: {e}")
             raise

--- a/src/dataset_foundry/utils/docker/container_manager.py
+++ b/src/dataset_foundry/utils/docker/container_manager.py
@@ -311,33 +311,33 @@ class ContainerManager:
         """Wait for a detached container to complete while streaming logs."""
         try:
             # Collect each stream in a separate buffer, plus an interweaved buffer for full logs
+            logs = []
             stdout = []
             stderr = []
-            logs = []
+            logs_stream = container.logs(stdout=True, stderr=True, stream=True, follow=True)
             stdout_stream = container.logs(stdout=True, stderr=False, stream=True, follow=True)
             stderr_stream = container.logs(stdout=False, stderr=True, stream=True, follow=True)
-            logs_stream = container.logs(stdout=True, stderr=True, stream=True, follow=True)
 
             # Only print the interweaved logs; the other streams are just for collection
+            logs_task = asyncio.create_task(
+                self._stream_container_logs(logs_stream, logs, container.id, stream_logs)
+            )
             stdout_task = asyncio.create_task(
                 self._stream_container_logs(stdout_stream, stdout, container.id, False)
             )
             stderr_task = asyncio.create_task(
                 self._stream_container_logs(stderr_stream, stderr, container.id, False)
             )
-            logs_task = asyncio.create_task(
-                self._stream_container_logs(logs_stream, logs, container.id, stream_logs)
-            )
 
             exit_code = await self._wait_for_container_completion(container, timeout)
 
+            await self._cleanup_log_task(logs_task)
             await self._cleanup_log_task(stdout_task)
             await self._cleanup_log_task(stderr_task)
-            await self._cleanup_log_task(logs_task)
 
+            await self._collect_remaining_logs(container, logs, stdout=True, stderr=True)
             await self._collect_remaining_logs(container, stdout, stdout=True, stderr=False)
             await self._collect_remaining_logs(container, stderr, stdout=False, stderr=True)
-            await self._collect_remaining_logs(container, logs, stdout=True, stderr=True)
 
             return ContainerResult(
                 exit_code=exit_code,

--- a/src/dataset_foundry/utils/docker/container_manager.py
+++ b/src/dataset_foundry/utils/docker/container_manager.py
@@ -1,0 +1,244 @@
+"""
+Container manager for orchestrating Docker containers.
+"""
+
+import asyncio
+import logging
+from pathlib import Path
+from typing import Dict, List, Optional
+from dataclasses import dataclass
+import docker
+from docker.errors import DockerException
+
+logger = logging.getLogger(__name__)
+
+
+@dataclass
+class ContainerConfig:
+    """Configuration for a Docker container."""
+    image: str
+    command: Optional[List[str]] = None
+    environment: Optional[Dict[str, str]] = None
+    volumes: Optional[Dict[str, Dict[str, str]]] = None
+    working_dir: Optional[str] = None
+    network_mode: Optional[str] = None
+    remove: bool = True
+    timeout: int = 3600
+
+
+@dataclass
+class ContainerResult:
+    """Result from container execution."""
+    exit_code: int
+    stdout: str
+    stderr: str
+    logs: str
+    container_id: str
+
+
+class ContainerManager:
+    """Manages Docker container lifecycle and execution."""
+
+    def __init__(self, docker_client: Optional[docker.DockerClient] = None):
+        """
+        Initialize the container manager.
+
+        Args:
+            docker_client: Optional Docker client instance
+        """
+        self.docker_client = docker_client or docker.from_env()
+
+    async def build_image(
+        self,
+        dockerfile_path: Path,
+        image_name: str,
+        build_args: Optional[Dict[str, str]] = None,
+        stream_logs: bool = False
+    ) -> str:
+        """
+        Build a Docker image from a Dockerfile.
+
+        Args:
+            dockerfile_path: Path to directory containing Dockerfile
+            image_name: Name for the built image
+            build_args: Optional build arguments
+            stream_logs: Whether to stream build logs to logger.info (default: False)
+
+        Returns:
+            Image ID of the built image
+        """
+        try:
+            logger.info(f"Building image {image_name} from {dockerfile_path}")
+
+            # Use low-level API for streaming logs
+            response = self.docker_client.api.build(
+                path=str(dockerfile_path),
+                tag=image_name,
+                buildargs=build_args,
+                rm=True,
+                decode=True
+            )
+
+            # Stream logs to logger
+            image_id = None
+            for chunk in response:
+                if 'stream' in chunk:
+                    log_line = chunk['stream'].strip()
+                    if stream_logs:
+                        logger.info(f"[Docker Build] {log_line}")
+                elif 'error' in chunk:
+                    error_msg = chunk['error'].strip()
+                    if error_msg:
+                        raise DockerException(error_msg)
+                elif 'aux' in chunk:
+                    # Extract image ID from aux data
+                    image_id = chunk['aux'].get('ID')
+
+            if not image_id:
+                raise DockerException("Failed to build image - no image ID returned")
+
+            logger.info(f"Successfully built image {image_name}: {image_id}")
+
+            return image_id
+
+        except DockerException as e:
+            logger.error(f"Error building image {image_name}: {e}")
+            raise
+
+    async def run_container(
+        self,
+        config: ContainerConfig,
+        timeout: Optional[int] = None,
+        stream_logs: bool = False
+    ) -> ContainerResult:
+        """
+        Run a container with the given configuration.
+
+        Args:
+            config: Container configuration
+            timeout: Optional timeout in seconds
+            stream_logs: Whether to stream container logs to logger.info (default: False)
+
+        Returns:
+            ContainerResult with execution details
+        """
+        container = None
+        try:
+            logger.debug(f"Running container {config.image} with command {config.command}")
+
+            container = self.docker_client.containers.run(
+                image=config.image,
+                command=config.command,
+                environment=config.environment,
+                volumes=config.volumes,
+                working_dir=config.working_dir,
+                network_mode=config.network_mode,
+                remove=config.remove,
+                detach=True,
+            )
+
+            return await self._wait_for_container(container, timeout or config.timeout, stream_logs)
+        except DockerException as e:
+            logger.error(f"Docker error: {e}")
+            raise
+        except Exception as e:
+            logger.error(f"Container execution error: {e}")
+            raise
+        finally:
+            # Handle orphaned containers - only if remove=False and container still exists
+            if container and not config.remove:
+                try:
+                    # Check if container still exists (hasn't been auto-removed)
+                    container.reload()
+                    logger.info(f"Container {container.id} completed successfully")
+                except Exception:
+                    # Container was already removed or doesn't exist
+                    pass
+
+    async def _wait_for_container(
+        self,
+        container,
+        timeout: int,
+        stream_logs: bool
+    ) -> ContainerResult:
+        """Wait for a detached container to complete while streaming logs."""
+        try:
+            logs = []
+            log_stream = container.logs(stdout=True, stderr=True, stream=True, follow=True)
+            log_task = asyncio.create_task(
+                self._stream_container_logs(log_stream, logs, container.id, stream_logs)
+            )
+
+            exit_code = await self._wait_for_container_completion(container, timeout)
+
+            await self._cleanup_log_task(log_task)
+            await self._collect_remaining_logs(container, logs)
+
+            full_logs = '\n'.join(logs)
+
+            return ContainerResult(
+                exit_code=exit_code,
+                stdout=full_logs,
+                stderr='',
+                logs=logs,
+                container_id=container.id
+            )
+
+        except Exception as e:
+            logger.error(f"Error waiting for container {container.id}: {e}")
+            raise
+
+    async def _stream_container_logs(
+        self,
+        log_stream,
+        logs_buffer: list,
+        container_id: str,
+        stream_logs: bool
+    ):
+        """Stream logs from container in real-time."""
+        try:
+            for log_chunk in log_stream:
+                log_line = log_chunk.decode('utf-8', errors='ignore').strip()
+                logs_buffer.append(log_line)
+                if stream_logs:
+                    logger.info(f"[Container {container_id[:12]}] {log_line}")
+        except Exception as e:
+            logger.warning(f"Error streaming logs: {e}")
+
+    async def _wait_for_container_completion(self, container, timeout: int) -> int:
+        """Wait for container to complete and return exit code."""
+        try:
+            result = await asyncio.wait_for(
+                asyncio.to_thread(container.wait),
+                timeout=timeout
+            )
+            return result.get('StatusCode', 0)
+        except asyncio.TimeoutError:
+            logger.warning(f"Container {container.id} timed out after {timeout} seconds")
+            # Stop the container if it timed out
+            container.stop(timeout=10)
+            return -1
+
+    async def _cleanup_log_task(self, log_task: asyncio.Task):
+        """Clean up the log streaming task."""
+        log_task.cancel()
+        try:
+            await log_task
+        except asyncio.CancelledError:
+            pass
+
+    async def _collect_remaining_logs(self, container, logs_buffer: list):
+        """Collect any remaining logs from the container."""
+        try:
+            # Check if container is still accessible and not dead/marked for removal
+            container.reload()
+            if container.status not in ['dead', 'removing', 'removed']:
+                remaining_logs = container.logs(stdout=True, stderr=True).decode('utf-8', errors='ignore')
+                if remaining_logs:
+                    remaining_lines = remaining_logs.strip().split('\n')
+                    for line in remaining_lines:
+                        logs_buffer.append(line)
+        except Exception as e:
+            print(f"Could not get remaining logs for container {container.id}: {e}")
+            # Container might have been removed or is inaccessible
+            pass

--- a/src/dataset_foundry/utils/docker/sandbox_runner.py
+++ b/src/dataset_foundry/utils/docker/sandbox_runner.py
@@ -1,0 +1,108 @@
+"""
+Sandbox manager for running unit tests in isolated Docker containers.
+"""
+
+import logging
+from copy import deepcopy
+from pathlib import Path
+from typing import List, Optional
+
+from docker.types import Mount
+from pydantic import BaseModel
+
+from .base_runner import BaseRunner, RunnerConfig
+from .container_manager import ContainerConfig, ContainerResult
+
+logger = logging.getLogger(__name__)
+
+
+class SandboxConfig(RunnerConfig):
+    """Configuration for a sandbox environment."""
+
+class SandboxResult(ContainerResult):
+    """Result from sandbox execution."""
+
+
+class SandboxRunner(BaseRunner):
+    """Manages sandbox environments for running code in isolated containers."""
+
+    def __init__(self, sandbox_name: str, container_manager=None):
+        """
+        Initialize the sandbox runner.
+
+        Args:
+            sandbox_name: Name of sandbox to use
+            container_manager: Optional container manager instance
+        """
+        super().__init__(sandbox_name, "sandboxes", "sandbox.yml", container_manager)
+
+    async def run(
+        self,
+        target_file: Path,
+        workspace_dir: Path,
+        command: Optional[List[str]] = None,
+        timeout: int = 300,
+        stream_logs: bool = False
+    ) -> SandboxResult:
+        """
+        Run code in a sandbox container.
+
+        Args:
+            target_file: Path to the target file to execute
+            workspace_dir: Directory containing all files to mount
+            command: Optional command to override the default
+            timeout: Timeout for execution in seconds (default: 300)
+            stream_logs: Whether to stream container logs
+
+        Returns:
+            SandboxResult with execution results
+        """
+        try:
+            if self._config is None:
+                self._config = await self._load_config()
+
+            await self._ensure_image_built(stream_logs)
+
+            container_config = self._create_container_config(
+                workspace_dir,
+                target_file,
+                command,
+            )
+
+            logger.info(f"Running sandbox {self.runner_name}")
+            result = await self.container_manager.run_container(
+                container_config,
+                timeout=timeout,
+                stream_logs=stream_logs
+            )
+
+            logger.info(f"Sandbox {self.runner_name} completed with exit code {result.exit_code}")
+            return result
+
+        except Exception as e:
+            logger.error(f"Sandbox execution failed: {e}")
+            raise
+
+    def _create_container_config(
+        self,
+        workspace_dir: Path,
+        target_file: Path,
+        command: Optional[List[str]] = None
+    ) -> ContainerConfig:
+        """Create container configuration for the sandbox."""
+        if not command:
+            raise ValueError("No command provided for sandbox")
+
+        config = deepcopy(self._config.container)
+        config.command = command
+
+        working_dir = self._get_working_dir(config)
+
+        self._prepare_volumes_config(config, [
+            Mount(target=working_dir, source=str(workspace_dir), type="bind", read_only=False)
+        ])
+        self._prepare_environment_config(config)
+
+        print("\n\nconfig:", config.volumes)
+
+        return config

--- a/src/dataset_foundry/utils/docker/sandbox_runner.py
+++ b/src/dataset_foundry/utils/docker/sandbox_runner.py
@@ -70,10 +70,17 @@ class SandboxRunner(BaseRunner):
             )
 
             logger.info(f"Running sandbox {self.runner_name}")
-            result = await self.container_manager.run_container(
+            container_result = await self.container_manager.run_container(
                 container_config,
                 timeout=timeout,
                 stream_logs=stream_logs
+            )
+            result = SandboxResult(
+                exit_code=container_result.exit_code,
+                stdout=container_result.stdout,
+                stderr=container_result.stderr,
+                logs=container_result.logs,
+                container_id=container_result.container_id
             )
 
             logger.info(f"Sandbox {self.runner_name} completed with exit code {result.exit_code}")

--- a/src/dataset_foundry/utils/docker/sandbox_runner.py
+++ b/src/dataset_foundry/utils/docker/sandbox_runner.py
@@ -110,6 +110,4 @@ class SandboxRunner(BaseRunner):
         ])
         self._prepare_environment_config(config)
 
-        print("\n\nconfig:", config.volumes)
-
         return config

--- a/src/dataset_foundry/utils/format/preprocess_template.py
+++ b/src/dataset_foundry/utils/format/preprocess_template.py
@@ -1,6 +1,6 @@
 import re
 import yaml
-import json
+import datason.json as json
 from typing import Any, Dict, Tuple, Optional
 
 from ...utils.get import get

--- a/src/dataset_foundry/utils/get_pipeline_metadata.py
+++ b/src/dataset_foundry/utils/get_pipeline_metadata.py
@@ -1,0 +1,13 @@
+from ..core.context import Context
+
+def get_pipeline_metadata(context: Context) -> dict:
+    """
+    Get the metadata for the active pipeline.
+    """
+    parent_metadata = get_pipeline_metadata(context.parent) if context.parent else None
+
+    return {
+        "name": context.pipeline.name,
+        **context.pipeline.metadata,
+        **({ "parent": parent_metadata } if parent_metadata else {}),
+    }

--- a/src/dataset_foundry/utils/params/resolve_environment_dict.py
+++ b/src/dataset_foundry/utils/params/resolve_environment_dict.py
@@ -43,10 +43,8 @@ def resolve_environment_dict(environment: Dict[str, Any]) -> Dict[str, Any]:
             system_value = os.environ.get(var_name)
 
             if system_value is not None and system_value != "":
-                print("...resolved", key, system_value)
                 environment[key] = system_value
             elif default_value is not None and default_value != "":
-                print("...resolved", key, default_value)
                 environment[key] = default_value
             else:
                 # Pass through the expression as-is

--- a/src/dataset_foundry/utils/params/resolve_environment_dict.py
+++ b/src/dataset_foundry/utils/params/resolve_environment_dict.py
@@ -9,13 +9,15 @@ logger = logging.getLogger(__name__)
 def resolve_environment_dict(environment: Dict[str, Any]) -> Dict[str, Any]:
     """
     Resolve variables within an environment dict from the system environment. Variables should be
-    in the form of ${VAR_NAME}.
+    in the form of `${VAR_NAME}`. Default values can be provided by using the format
+    `${VAR_NAME:-default_value}`.
 
-    For example, here `LOGIN` will be resolved to the value of the `USER` environment variable:
+    For example, here `LOGIN` will be resolved to the value of the `USER` environment variable, or
+    `root` if the `USER` environment variable is not set:
 
     ```
     environment = resolve_environment_dict({
-        "LOGIN": "${USER}"
+        "LOGIN": "${USER:-root}"
     })
     ```
 
@@ -33,14 +35,21 @@ def resolve_environment_dict(environment: Dict[str, Any]) -> Dict[str, Any]:
 
     for key, value in environment.items():
         if isinstance(value, str) and value.startswith("${") and value.endswith("}"):
-            # Extract variable name and get from system environment
-            var_name = value[2:-1]  # Remove ${ and }
+            inner = value[2:-1]  # Remove ${ and }
+            if ':-' in inner:
+                var_name, default_value = inner.split(':-', 1)
+            else:
+                var_name, default_value = inner, None
             system_value = os.environ.get(var_name)
 
-            if system_value:
+            if system_value is not None and system_value != "":
+                print("...resolved", key, system_value)
                 environment[key] = system_value
+            elif default_value is not None and default_value != "":
+                print("...resolved", key, default_value)
+                environment[key] = default_value
             else:
                 # Pass through the expression as-is
-                logger.warning(f"Environment variable {var_name} not found")
+                logger.warning(f"Environment variable {var_name} not found and no default provided")
 
     return environment

--- a/src/dataset_foundry/utils/params/resolve_environment_dict.py
+++ b/src/dataset_foundry/utils/params/resolve_environment_dict.py
@@ -1,0 +1,46 @@
+import logging
+import os
+
+from copy import deepcopy
+from typing import Dict, Any
+
+logger = logging.getLogger(__name__)
+
+def resolve_environment_dict(environment: Dict[str, Any]) -> Dict[str, Any]:
+    """
+    Resolve variables within an environment dict from the system environment. Variables should be
+    in the form of ${VAR_NAME}.
+
+    For example, here `LOGIN` will be resolved to the value of the `USER` environment variable:
+
+    ```
+    environment = resolve_environment_dict({
+        "LOGIN": "${USER}"
+    })
+    ```
+
+    Args:
+        environment (Dict[str, Any]): The environment dictionary to resolve.
+
+    Returns:
+        Dict[str, Any]: The resolved environment dictionary.
+    """
+    if not environment or not isinstance(environment, dict):
+        return environment
+
+    # Ensure we don't modify the original environment dictionary
+    environment = deepcopy(environment)
+
+    for key, value in environment.items():
+        if isinstance(value, str) and value.startswith("${") and value.endswith("}"):
+            # Extract variable name and get from system environment
+            var_name = value[2:-1]  # Remove ${ and }
+            system_value = os.environ.get(var_name)
+
+            if system_value:
+                environment[key] = system_value
+            else:
+                # Pass through the expression as-is
+                logger.warning(f"Environment variable {var_name} not found")
+
+    return environment

--- a/src/dataset_foundry/utils/params/resolve_value.py
+++ b/src/dataset_foundry/utils/params/resolve_value.py
@@ -30,7 +30,7 @@ def resolve_value(
         else:
             resolved_value = value
 
-    if required_as and not resolved_value:
+    if required_as and (resolved_value is None or resolved_value == ""):
         raise ValueError(f"'{required_as}' must be passed in or defined in the data or context")
 
     logger.debug(

--- a/src/dataset_foundry/utils/params/resolve_value.py
+++ b/src/dataset_foundry/utils/params/resolve_value.py
@@ -1,5 +1,4 @@
 import logging
-from toolz import get_in
 from typing import Any, Callable, Optional, Union
 
 from ...core.context import Context

--- a/src/dataset_foundry/utils/save_messages.py
+++ b/src/dataset_foundry/utils/save_messages.py
@@ -1,4 +1,4 @@
-import json
+import datason.json as json
 from pathlib import Path
 import textwrap
 from typing import Any, List, Union

--- a/src/dataset_foundry/utils/unit_tests/parse_python_unit_test_results.py
+++ b/src/dataset_foundry/utils/unit_tests/parse_python_unit_test_results.py
@@ -1,0 +1,48 @@
+"""
+Parse sandbox results into unit test results.
+"""
+
+import re
+from pathlib import Path
+
+from dataset_foundry.types.unit_test_result import UnitTestResult
+from dataset_foundry.utils.docker.sandbox_runner import SandboxResult
+
+
+def parse_python_unit_test_results(result: SandboxResult) -> UnitTestResult:
+    """
+    Parse a `SandboxResult` into a `UnitTestResult`.
+
+    This function attempts to extract test results from the sandbox output, particularly looking for
+    pytest-style output patterns.
+
+    Args:
+        result: The result from sandbox execution
+
+    Returns:
+        `UnitTestResult` with parsed test information
+    """
+    stdout = result.stdout
+    stderr = result.stderr
+
+    # Try to parse pytest output if it looks like test results
+    passed_match = re.search(r'(\d+)\s*passed', stdout)
+    failed_match = re.search(r'(\d+)\s*failed', stdout)
+
+    if passed_match or failed_match:
+        # This looks like pytest output
+        num_passed = int(passed_match.group(1)) if passed_match else 0
+        num_failed = int(failed_match.group(1)) if failed_match else 0
+    else:
+        # Generic execution - treat as success/failure based on exit code
+        num_passed = 1 if result.exit_code == 0 else 0
+        num_failed = 1 if result.exit_code != 0 else 0
+
+    return UnitTestResult(
+        command=[f"docker run {result.container_id}"],
+        num_passed=num_passed,
+        num_failed=num_failed,
+        returncode=result.exit_code,
+        stdout=stdout,
+        stderr=stderr
+    )

--- a/tests/test_foreach_item.py
+++ b/tests/test_foreach_item.py
@@ -1,0 +1,111 @@
+import pytest
+from unittest.mock import MagicMock
+
+from dataset_foundry.actions.item.foreach_item_element import foreach_item_element
+from dataset_foundry.core.dataset_item import DatasetItem
+from dataset_foundry.core.context import Context
+from dataset_foundry.core.key import Key
+
+@pytest.mark.asyncio
+async def test_foreach_item_element_basic():
+    item = DatasetItem("test_id", {
+        "numbers": [1, 2, 3],
+        "results": []
+    })
+    context = MagicMock()
+    seen = []
+    async def record_action(item, context):
+        seen.append((item.data.get("element"), item.data.get("index")))
+    foreach_action = foreach_item_element(
+        collection=Key("numbers"),
+        actions=[record_action]
+    )
+    await foreach_action(item, context)
+    assert seen == [(1, 0), (2, 1), (3, 2)]
+
+@pytest.mark.asyncio
+async def test_foreach_item_element_custom_keys():
+    item = DatasetItem("test_id", {
+        "strings": ["a", "b"],
+        "results": []
+    })
+    context = MagicMock()
+    seen = []
+    async def record_action(item, context):
+        seen.append((item.data.get("element"), item.data.get("index")))
+    foreach_action = foreach_item_element(
+        collection=Key("strings"),
+        actions=[record_action]
+    )
+    await foreach_action(item, context)
+    assert seen == [("a", 0), ("b", 1)]
+
+@pytest.mark.asyncio
+async def test_foreach_item_element_non_iterable():
+    item = DatasetItem("test_id", {
+        "not_a_list": "string"
+    })
+    context = MagicMock()
+    async def record_action(item, context):
+        pass  # This should not be called
+    foreach_action = foreach_item_element(
+        collection=Key("not_a_list"),
+        actions=[record_action]
+    )
+    with pytest.raises(ValueError, match="'collection' is not iterable"):
+        await foreach_action(item, context)
+
+@pytest.mark.asyncio
+async def test_foreach_item_element_empty_collection():
+    item = DatasetItem("test_id", {
+        "empty_list": []
+    })
+    context = MagicMock()
+    seen = []
+    async def record_action(item, context):
+        seen.append(item.data.get("element"))
+    foreach_action = foreach_item_element(
+        collection=Key("empty_list"),
+        actions=[record_action]
+    )
+    await foreach_action(item, context)
+    assert seen == []
+
+@pytest.mark.asyncio
+async def test_foreach_item_element_parent_reference():
+    item = DatasetItem("test_id", {
+        "numbers": [1, 2],
+        "results": []
+    })
+    context = MagicMock()
+    seen = []
+    async def record_action(item, context):
+        seen.append((item.data.get("element"), item.data.get("parent")))
+    foreach_action = foreach_item_element(
+        collection=Key("numbers"),
+        actions=[record_action]
+    )
+    await foreach_action(item, context)
+    assert len(seen) == 2
+    assert seen[0][0] == 1
+    assert seen[1][0] == 2
+    # Check that parent references point to the original item
+    assert seen[0][1] is item
+    assert seen[1][1] is item
+
+@pytest.mark.asyncio
+async def test_foreach_item_element_item_id_generation():
+    item = DatasetItem("test_id", {
+        "numbers": [1, 2],
+        "results": []
+    })
+    context = MagicMock()
+    seen_ids = []
+    async def record_action(item, context):
+        seen_ids.append(item.id)
+    foreach_action = foreach_item_element(
+        collection=Key("numbers"),
+        actions=[record_action]
+    )
+    await foreach_action(item, context)
+    assert seen_ids == ["test_id_0", "test_id_1"]

--- a/tests/test_get.py
+++ b/tests/test_get.py
@@ -1,0 +1,223 @@
+import pytest
+from dataset_foundry.utils.get import get
+
+
+class TestGet:
+    """Comprehensive test suite for the get function."""
+
+    def test_nested_dict_with_string_path(self):
+        """Test accessing nested dictionary using dot-separated string path."""
+        data = {'a': {'b': {'c': 1}}}
+        assert get(data, 'a.b.c') == 1
+        assert get(data, 'a.b') == {'c': 1}
+        assert get(data, 'a') == {'b': {'c': 1}}
+
+    def test_nested_dict_with_list_path(self):
+        """Test accessing nested dictionary using list path."""
+        data = {'a': {'b': {'c': 1}}}
+        assert get(data, ['a', 'b', 'c']) == 1
+        assert get(data, ['a', 'b']) == {'c': 1}
+        assert get(data, ['a']) == {'b': {'c': 1}}
+
+    def test_object_attributes(self):
+        """Test accessing object attributes."""
+        class TestObj:
+            def __init__(self):
+                self.a = {'b': 3}
+                self.x = 42
+
+        obj = TestObj()
+        assert get(obj, 'a.b') == 3
+        assert get(obj, 'x') == 42
+        assert get(obj, 'a') == {'b': 3}
+
+    def test_mixed_dict_and_object_access(self):
+        """Test accessing object with dictionary attributes."""
+        class TestObj:
+            def __init__(self):
+                self.data = {'nested': {'value': 'test'}}
+                self.simple = 123
+
+        obj = TestObj()
+        assert get(obj, 'data.nested.value') == 'test'
+        assert get(obj, 'simple') == 123
+
+    def test_default_value_when_path_not_found(self):
+        """Test that default value is returned when path doesn't exist."""
+        data = {'a': {'b': 1}}
+
+        # Test with string path - should return None, not default, because no exception is raised
+        assert get(data, 'a.b.c') is None
+        assert get(data, 'x.y.z') is None
+
+        # Test with list path - should return None, not default, because no exception is raised
+        assert get(data, ['a', 'b', 'c']) is None
+        assert get(data, ['x', 'y']) is None
+
+        # Test cases where exceptions are actually raised (these should use default)
+        # Create an object that will raise an exception when accessing non-existent keys
+        class ExceptionRaisingObj:
+            def __getitem__(self, key):
+                raise KeyError(f"Key '{key}' not found")
+
+        obj = ExceptionRaisingObj()
+        assert get(obj, 'nonexistent', default='error') == 'error'
+
+    def test_default_value_with_none_default(self):
+        """Test that None is returned when no default is specified."""
+        data = {'a': {'b': 1}}
+        assert get(data, 'a.b.c') is None
+        assert get(data, 'x.y.z') is None
+        assert get(data, 'a.d') is None
+
+    def test_empty_path(self):
+        """Test behavior with empty path."""
+        data = {'a': 1}
+
+        # Empty string path - should return None because split('.') on empty string gives ['']
+        assert get(data, '') is None
+
+        # Empty list path - should return the original object
+        assert get(data, []) == data
+
+    def test_single_level_access(self):
+        """Test accessing single level keys/attributes."""
+        data = {'key': 'value'}
+        assert get(data, 'key') == 'value'
+        assert get(data, ['key']) == 'value'
+
+    def test_none_object(self):
+        """Test behavior when object is None."""
+        assert get(None, 'any.path') is None
+        assert get(None, 'any.path', default='default') is None
+
+    def test_non_dict_non_object_access(self):
+        """Test accessing attributes of non-dict, non-object types."""
+        # Test with list - getattr returns the method object, not the result
+        lst = [1, 2, 3]
+        assert get(lst, '__len__') == lst.__len__
+
+        # Test with string - getattr returns the method object, not the result
+        s = "hello"
+        assert get(s, '__len__') == s.__len__
+
+    def test_dict_with_get_method(self):
+        """Test accessing dictionary that has get method."""
+        class DictWithGet:
+            def __init__(self, data):
+                self._data = data
+
+            def get(self, key, default=None):
+                return self._data.get(key, default)
+
+            def __getitem__(self, key):
+                return self._data[key]
+
+            def __contains__(self, key):
+                return key in self._data
+
+        obj = DictWithGet({'a': {'b': 2}})
+        assert get(obj, 'a.b') == 2
+        assert get(obj, 'x') is None  # Should return None, not default
+
+    def test_object_without_get_method(self):
+        """Test accessing object that doesn't have get method."""
+        class SimpleObj:
+            def __init__(self):
+                self.attr = 'value'
+                self.nested = {'key': 'nested_value'}
+
+        obj = SimpleObj()
+        assert get(obj, 'attr') == 'value'
+        assert get(obj, 'nested.key') == 'nested_value'
+
+    def test_complex_nested_structure(self):
+        """Test accessing deeply nested mixed structure."""
+        class NestedObj:
+            def __init__(self):
+                self.level1 = {
+                    'level2': {
+                        'level3': {
+                            'final': 'success'
+                        }
+                    }
+                }
+
+        obj = NestedObj()
+        assert get(obj, 'level1.level2.level3.final') == 'success'
+        assert get(obj, ['level1', 'level2', 'level3', 'final']) == 'success'
+
+    def test_path_with_special_characters(self):
+        """Test path with dots in keys (should be treated as separators)."""
+        data = {'a.b': {'c': 1}, 'a': {'b': 2}}
+
+        # This should look for key 'a' then 'b' then 'c' (which doesn't exist)
+        assert get(data, 'a.b.c') is None
+
+        # This should look for key 'a' then 'b'
+        assert get(data, 'a.b') == 2
+
+    def test_list_path_with_special_characters(self):
+        """Test list path with dots in keys."""
+        data = {'a.b': {'c': 1}, 'a': {'b': 2}}
+
+        # List path should work with dots in keys
+        assert get(data, ['a.b', 'c']) == 1
+        assert get(data, ['a', 'b']) == 2
+
+    def test_error_handling(self):
+        """Test that errors are properly caught and default is returned."""
+        data = {'a': 1}
+
+        # Accessing non-existent attribute on int - should return None, not default
+        assert get(data, 'a.nonexistent') is None
+        assert get(data, 'a.nonexistent', default='error') is None
+
+    def test_edge_cases(self):
+        """Test various edge cases."""
+        # Empty dictionary
+        assert get({}, 'any.path') is None
+
+        # Dictionary with None values
+        data = {'a': None, 'b': {'c': None}}
+        assert get(data, 'a') is None
+        assert get(data, 'b.c') is None
+
+        # Path with only dots - should return None because split('.') on '...' gives ['', '', '']
+        data = {'a': 1}
+        assert get(data, '...') is None
+
+    def test_docstring_examples(self):
+        """Test the examples provided in the docstring."""
+        # Note: Docstring shows 'get_in' but function is named 'get'
+        data = {'a': {'b': {'c': 1}}}
+        assert get(data, 'a.b.c') == 1
+        assert get(data, ['a', 'b', 'c']) == 1
+
+        class Obj:
+            pass
+
+        o = Obj()
+        o.a = {'b': 3}
+        assert get(o, 'a.b') == 3
+
+    def test_type_safety(self):
+        """Test that function handles different types correctly."""
+        # Test with various data types - getattr returns the method object, not the result
+        assert get(42, '__class__') == int
+
+        # Test with string - use the same string object
+        s = "hello"
+        assert get(s, '__len__') == s.__len__
+
+        # Test with list - use the same list object
+        lst = [1, 2, 3]
+        assert get(lst, '__len__') == lst.__len__
+
+        # Test with custom objects
+        class CustomType:
+            def __init__(self, value):
+                self.value = value
+
+        obj = CustomType("test")
+        assert get(obj, 'value') == "test"

--- a/tests/test_sandbox_runner.py
+++ b/tests/test_sandbox_runner.py
@@ -87,14 +87,14 @@ def example_function():
 
         # Mock the image building
         with patch.object(sandbox_runner, '_ensure_image_built'):
-        # Run tests
-        result = await sandbox_runner.run(
-            target_file=test_file,
-            workspace_dir=tmp_path,
-            command=["python", "-m", "pytest", "-v", test_file.name],
-            timeout=300,
-            stream_logs=False
-        )
+            # Run tests
+            result = await sandbox_runner.run(
+                target_file=test_file,
+                workspace_dir=tmp_path,
+                command=["python", "-m", "pytest", "-v", test_file.name],
+                timeout=300,
+                stream_logs=False
+            )
 
         # Verify result
         assert isinstance(result, SandboxResult)

--- a/tests/test_sandbox_runner.py
+++ b/tests/test_sandbox_runner.py
@@ -1,0 +1,167 @@
+"""
+Tests for the sandbox manager functionality.
+"""
+
+import pytest
+from pathlib import Path
+from unittest.mock import Mock, AsyncMock, patch
+
+from dataset_foundry.utils.docker.sandbox_runner import SandboxRunner, SandboxConfig, SandboxResult
+from dataset_foundry.utils.docker.container_manager import ContainerConfig, ContainerResult
+from dataset_foundry.types.unit_test_result import UnitTestResult
+
+
+class TestSandboxConfig:
+    """Test SandboxConfig class."""
+
+    def test_sandbox_config_creation(self):
+        """Test creating a SandboxConfig instance."""
+        container_config = ContainerConfig(
+            image="test-image:latest",
+            command=["python"]
+        )
+
+        config = SandboxConfig(
+            container=container_config
+        )
+
+        assert config.container.image == "test-image:latest"
+        assert config.container.command == ["python"]
+
+
+class TestSandboxRunner:
+    """Test SandboxRunner class."""
+
+    def test_sandbox_runner_initialization(self):
+        """Test SandboxRunner initialization."""
+        container_manager = Mock()
+        sandbox_runner = SandboxRunner("test-sandbox", container_manager)
+
+        assert sandbox_runner.container_manager == container_manager
+        assert sandbox_runner.runner_name == "test-sandbox"
+
+    @pytest.mark.asyncio
+    async def test_run_tests_in_sandbox(self, tmp_path):
+        """Test running tests in sandbox."""
+        # Create test files
+        test_file = tmp_path / "test_example.py"
+        test_file.write_text("""
+import pytest
+
+def test_example():
+    assert True
+""")
+
+        source_file = tmp_path / "example.py"
+        source_file.write_text("""
+def example_function():
+    return True
+""")
+
+        # Mock container manager
+        container_manager = Mock()
+        container_manager.image_exists.return_value = True
+
+        # Mock container result
+        mock_result = ContainerResult(
+            exit_code=0,
+            stdout="1 passed",
+            stderr="",
+            logs="",
+            container_id="test-container-id"
+        )
+
+        container_manager.run_container = AsyncMock(return_value=mock_result)
+
+        # Create sandbox runner
+        sandbox_runner = SandboxRunner("test-sandbox", container_manager)
+
+        # Mock the config loading
+        with patch.object(sandbox_runner, '_load_config'):
+            sandbox_runner._config = SandboxConfig(
+            container=ContainerConfig(
+                image="test-image:latest",
+                command=["python"]
+            )
+        )
+
+        # Mock the image building
+        with patch.object(sandbox_runner, '_ensure_image_built'):
+        # Run tests
+        result = await sandbox_runner.run(
+            target_file=test_file,
+            workspace_dir=tmp_path,
+            command=["python", "-m", "pytest", "-v", test_file.name],
+            timeout=300,
+            stream_logs=False
+        )
+
+        # Verify result
+        assert isinstance(result, SandboxResult)
+        assert result.exit_code == 0
+        assert result.stdout == "1 passed"
+        assert result.stderr == ""
+        assert result.container_id == "test-container-id"
+
+    def test_create_container_config(self):
+        """Test container configuration creation."""
+        container_manager = Mock()
+        sandbox_runner = SandboxRunner("test-sandbox", container_manager)
+
+        # Mock the config
+        sandbox_runner._config = SandboxConfig(
+            container=ContainerConfig(
+                image="test-image:latest",
+                environment={"TEST_VAR": "test_value"},
+                command=["python"]
+            )
+        )
+
+        workspace_path = Path("/tmp/workspace")
+        test_file = Path("/tmp/test.py")
+        command = ["python", test_file.name]
+
+        config = sandbox_runner._create_container_config(
+            workspace_path,
+            test_file,
+            command
+        )
+
+        assert config.image == "test-image:latest"
+        assert config.command == command
+        assert config.environment == {"TEST_VAR": "test_value"}
+
+    def test_create_container_config_no_command(self):
+        """Test container configuration creation with no command."""
+        container_manager = Mock()
+        sandbox_runner = SandboxRunner("test-sandbox", container_manager)
+
+        workspace_path = Path("/tmp/workspace")
+        test_file = Path("/tmp/test.py")
+
+        with pytest.raises(ValueError, match="No command provided for sandbox"):
+            sandbox_runner._create_container_config(
+                workspace_path,
+                test_file,
+                None
+            )
+
+
+class TestSandboxResult:
+    """Test SandboxResult class."""
+
+    def test_sandbox_result_creation(self):
+        """Test creating a SandboxResult instance."""
+        result = SandboxResult(
+            exit_code=0,
+            stdout="test output",
+            stderr="test error",
+            logs="test logs",
+            container_id="test-container-id"
+        )
+
+        assert result.exit_code == 0
+        assert result.stdout == "test output"
+        assert result.stderr == "test error"
+        assert result.logs == "test logs"
+        assert result.container_id == "test-container-id"

--- a/uv.lock
+++ b/uv.lock
@@ -138,6 +138,7 @@ name = "dataset-foundry"
 version = "0.1.0"
 source = { editable = "." }
 dependencies = [
+    { name = "datason" },
     { name = "docker" },
     { name = "langchain" },
     { name = "langchain-anthropic" },
@@ -153,6 +154,7 @@ dependencies = [
 
 [package.metadata]
 requires-dist = [
+    { name = "datason", specifier = ">=0.13.0" },
     { name = "docker", specifier = ">=7.1.0" },
     { name = "langchain", specifier = "==0.3.21" },
     { name = "langchain-anthropic", specifier = "==0.3.10" },
@@ -164,6 +166,15 @@ requires-dist = [
     { name = "python-dotenv", specifier = "==1.0.1" },
     { name = "pyyaml", specifier = "==6.0.2" },
     { name = "toolz", specifier = ">=1.0.0" },
+]
+
+[[package]]
+name = "datason"
+version = "0.13.0"
+source = { registry = "https://pypi.org/simple" }
+sdist = { url = "https://files.pythonhosted.org/packages/ff/9a/3f80f36831fd002a4cd02f609c940b50a697b9bd1f533595a8063f9057b9/datason-0.13.0.tar.gz", hash = "sha256:ac3ba69586501fe8d6cf039d75ecaf5659bc16ff089d71f60d73e398505900dd", size = 511930 }
+wheels = [
+    { url = "https://files.pythonhosted.org/packages/18/04/1dc0c30a511736f075f37162573b23da7102c643419865a2a96fa27434f1/datason-0.13.0-py3-none-any.whl", hash = "sha256:7ea24bd73ec04a9ea0a23b15061c94e4f62838c465f8205c4bf5e2a91de458cc", size = 129970 },
 ]
 
 [[package]]

--- a/uv.lock
+++ b/uv.lock
@@ -138,6 +138,7 @@ name = "dataset-foundry"
 version = "0.1.0"
 source = { editable = "." }
 dependencies = [
+    { name = "docker" },
     { name = "langchain" },
     { name = "langchain-anthropic" },
     { name = "langchain-core" },
@@ -152,6 +153,7 @@ dependencies = [
 
 [package.metadata]
 requires-dist = [
+    { name = "docker", specifier = ">=7.1.0" },
     { name = "langchain", specifier = "==0.3.21" },
     { name = "langchain-anthropic", specifier = "==0.3.10" },
     { name = "langchain-core", specifier = "==0.3.45" },
@@ -171,6 +173,20 @@ source = { registry = "https://pypi.org/simple" }
 sdist = { url = "https://files.pythonhosted.org/packages/fc/f8/98eea607f65de6527f8a2e8885fc8015d3e6f5775df186e443e0964a11c3/distro-1.9.0.tar.gz", hash = "sha256:2fa77c6fd8940f116ee1d6b94a2f90b13b5ea8d019b98bc8bafdcabcdd9bdbed", size = 60722 }
 wheels = [
     { url = "https://files.pythonhosted.org/packages/12/b3/231ffd4ab1fc9d679809f356cebee130ac7daa00d6d6f3206dd4fd137e9e/distro-1.9.0-py3-none-any.whl", hash = "sha256:7bffd925d65168f85027d8da9af6bddab658135b840670a223589bc0c8ef02b2", size = 20277 },
+]
+
+[[package]]
+name = "docker"
+version = "7.1.0"
+source = { registry = "https://pypi.org/simple" }
+dependencies = [
+    { name = "pywin32", marker = "sys_platform == 'win32'" },
+    { name = "requests" },
+    { name = "urllib3" },
+]
+sdist = { url = "https://files.pythonhosted.org/packages/91/9b/4a2ea29aeba62471211598dac5d96825bb49348fa07e906ea930394a83ce/docker-7.1.0.tar.gz", hash = "sha256:ad8c70e6e3f8926cb8a92619b832b4ea5299e2831c14284663184e200546fa6c", size = 117834 }
+wheels = [
+    { url = "https://files.pythonhosted.org/packages/e3/26/57c6fb270950d476074c087527a558ccb6f4436657314bfb6cdf484114c4/docker-7.1.0-py3-none-any.whl", hash = "sha256:c96b93b7f0a746f9e77d325bcfb87422a3d8bd4f03136ae8a85b37f1898d5fc0", size = 147774 },
 ]
 
 [[package]]
@@ -577,6 +593,22 @@ source = { registry = "https://pypi.org/simple" }
 sdist = { url = "https://files.pythonhosted.org/packages/bc/57/e84d88dfe0aec03b7a2d4327012c1627ab5f03652216c63d49846d7a6c58/python-dotenv-1.0.1.tar.gz", hash = "sha256:e324ee90a023d808f1959c46bcbc04446a10ced277783dc6ee09987c37ec10ca", size = 39115 }
 wheels = [
     { url = "https://files.pythonhosted.org/packages/6a/3e/b68c118422ec867fa7ab88444e1274aa40681c606d59ac27de5a5588f082/python_dotenv-1.0.1-py3-none-any.whl", hash = "sha256:f7b63ef50f1b690dddf550d03497b66d609393b40b564ed0d674909a68ebf16a", size = 19863 },
+]
+
+[[package]]
+name = "pywin32"
+version = "311"
+source = { registry = "https://pypi.org/simple" }
+wheels = [
+    { url = "https://files.pythonhosted.org/packages/e7/ab/01ea1943d4eba0f850c3c61e78e8dd59757ff815ff3ccd0a84de5f541f42/pywin32-311-cp312-cp312-win32.whl", hash = "sha256:750ec6e621af2b948540032557b10a2d43b0cee2ae9758c54154d711cc852d31", size = 8706543 },
+    { url = "https://files.pythonhosted.org/packages/d1/a8/a0e8d07d4d051ec7502cd58b291ec98dcc0c3fff027caad0470b72cfcc2f/pywin32-311-cp312-cp312-win_amd64.whl", hash = "sha256:b8c095edad5c211ff31c05223658e71bf7116daa0ecf3ad85f3201ea3190d067", size = 9495040 },
+    { url = "https://files.pythonhosted.org/packages/ba/3a/2ae996277b4b50f17d61f0603efd8253cb2d79cc7ae159468007b586396d/pywin32-311-cp312-cp312-win_arm64.whl", hash = "sha256:e286f46a9a39c4a18b319c28f59b61de793654af2f395c102b4f819e584b5852", size = 8710102 },
+    { url = "https://files.pythonhosted.org/packages/a5/be/3fd5de0979fcb3994bfee0d65ed8ca9506a8a1260651b86174f6a86f52b3/pywin32-311-cp313-cp313-win32.whl", hash = "sha256:f95ba5a847cba10dd8c4d8fefa9f2a6cf283b8b88ed6178fa8a6c1ab16054d0d", size = 8705700 },
+    { url = "https://files.pythonhosted.org/packages/e3/28/e0a1909523c6890208295a29e05c2adb2126364e289826c0a8bc7297bd5c/pywin32-311-cp313-cp313-win_amd64.whl", hash = "sha256:718a38f7e5b058e76aee1c56ddd06908116d35147e133427e59a3983f703a20d", size = 9494700 },
+    { url = "https://files.pythonhosted.org/packages/04/bf/90339ac0f55726dce7d794e6d79a18a91265bdf3aa70b6b9ca52f35e022a/pywin32-311-cp313-cp313-win_arm64.whl", hash = "sha256:7b4075d959648406202d92a2310cb990fea19b535c7f4a78d3f5e10b926eeb8a", size = 8709318 },
+    { url = "https://files.pythonhosted.org/packages/c9/31/097f2e132c4f16d99a22bfb777e0fd88bd8e1c634304e102f313af69ace5/pywin32-311-cp314-cp314-win32.whl", hash = "sha256:b7a2c10b93f8986666d0c803ee19b5990885872a7de910fc460f9b0c2fbf92ee", size = 8840714 },
+    { url = "https://files.pythonhosted.org/packages/90/4b/07c77d8ba0e01349358082713400435347df8426208171ce297da32c313d/pywin32-311-cp314-cp314-win_amd64.whl", hash = "sha256:3aca44c046bd2ed8c90de9cb8427f581c479e594e99b5c0bb19b29c10fd6cb87", size = 9656800 },
+    { url = "https://files.pythonhosted.org/packages/c0/d2/21af5c535501a7233e734b8af901574572da66fcc254cb35d0609c9080dd/pywin32-311-cp314-cp314-win_arm64.whl", hash = "sha256:a508e2d9025764a8270f93111a970e1d0fbfc33f4153b388bb649b7eec4f9b42", size = 8932540 },
 ]
 
 [[package]]

--- a/uv.lock
+++ b/uv.lock
@@ -144,6 +144,7 @@ dependencies = [
     { name = "langchain-openai" },
     { name = "pydantic" },
     { name = "pytest" },
+    { name = "pytest-asyncio" },
     { name = "python-dotenv" },
     { name = "pyyaml" },
     { name = "toolz" },
@@ -157,6 +158,7 @@ requires-dist = [
     { name = "langchain-openai", specifier = "==0.3.9" },
     { name = "pydantic", specifier = ">=2.10.6" },
     { name = "pytest", specifier = ">=8.3.4" },
+    { name = "pytest-asyncio", specifier = ">=1.0.0" },
     { name = "python-dotenv", specifier = "==1.0.1" },
     { name = "pyyaml", specifier = "==6.0.2" },
     { name = "toolz", specifier = ">=1.0.0" },
@@ -554,6 +556,18 @@ dependencies = [
 sdist = { url = "https://files.pythonhosted.org/packages/05/35/30e0d83068951d90a01852cb1cef56e5d8a09d20c7f511634cc2f7e0372a/pytest-8.3.4.tar.gz", hash = "sha256:965370d062bce11e73868e0335abac31b4d3de0e82f4007408d242b4f8610761", size = 1445919 }
 wheels = [
     { url = "https://files.pythonhosted.org/packages/11/92/76a1c94d3afee238333bc0a42b82935dd8f9cf8ce9e336ff87ee14d9e1cf/pytest-8.3.4-py3-none-any.whl", hash = "sha256:50e16d954148559c9a74109af1eaf0c945ba2d8f30f0a3d3335edde19788b6f6", size = 343083 },
+]
+
+[[package]]
+name = "pytest-asyncio"
+version = "1.0.0"
+source = { registry = "https://pypi.org/simple" }
+dependencies = [
+    { name = "pytest" },
+]
+sdist = { url = "https://files.pythonhosted.org/packages/d0/d4/14f53324cb1a6381bef29d698987625d80052bb33932d8e7cbf9b337b17c/pytest_asyncio-1.0.0.tar.gz", hash = "sha256:d15463d13f4456e1ead2594520216b225a16f781e144f8fdf6c5bb4667c48b3f", size = 46960 }
+wheels = [
+    { url = "https://files.pythonhosted.org/packages/30/05/ce271016e351fddc8399e546f6e23761967ee09c8c568bbfbecb0c150171/pytest_asyncio-1.0.0-py3-none-any.whl", hash = "sha256:4f024da9f1ef945e680dc68610b52550e36590a67fd31bb3b4943979a1f90ef3", size = 15976 },
 ]
 
 [[package]]


### PR DESCRIPTION
##  Enhancements

### New Actions

- `exec_item`: Run a command for a single dataset item.
- `foreach_item_element`: Apply logic across sub-elements of a dataset item.
- `save_dataset_chat`: Save chat history when generating a dataset.
- `get_pipeline_metadata`: Extract pipeline metadata into items.

### Updated Actions

- `items_key`: New parameter in `load_dataset` to specify subkeys.

### New Infrastructure

- **SWE Agent Support**:
  - Added SWE agent support for Codex and Claude Code.
  - Introduced `AgentRunner`, `BaseRunner`, and `SandboxRunner`.

- **Docker Integration**:
  - Added container management utilities that mimic `docker-compose.yml`.

- **Sandboxing & Environment Resolution**:
  - Added Python sandbox configuration, including dependency installation and support for running unit tests in isolation.
  - Improved environment resolution utilities with defaults and parameter support.

##  Refactors

- Switched core data structures from `dataclasses` to **Pydantic models**.
- Modularized runner logic
- Upgraded `agent.yml` format to match new agent system.

## Dependencies

### New
  - `pytest-asyncio` v1.0.0
  - `docker` v7.1.0
  - `datason` v0.13.0