### PR TITLE
Fix lookup error exiting app

### DIFF
--- a/src/dataset_foundry/displays/full/full_display.py
+++ b/src/dataset_foundry/displays/full/full_display.py
@@ -1,5 +1,3 @@
-import asyncio
-
 from ...core.pipeline import Pipeline
 from ..core.display import Display
 from ..core.pipeline_log_handler import install_pipeline_log_handler
@@ -10,36 +8,10 @@ class FullDisplay(Display):
         install_pipeline_log_handler(log_level)
 
     async def run_pipeline(self, pipeline: Pipeline, params: dict):
-        app = FullDisplayApp()
-
-        async def run_pipeline_task():
-            await pipeline.run(params=params)
-
-        async def run_app_task():
-            await app.run_async()
-
-        pipeline_task = asyncio.create_task(run_pipeline_task())
-        app_task = asyncio.create_task(run_app_task())
-
-        done, _pending = await asyncio.wait(
-            {pipeline_task, app_task},
-            return_when=asyncio.FIRST_COMPLETED,
-        )
-
-        if app_task in done and not pipeline_task.done():
-            print("Shutting down Docker containers... Please wait for cleanup to complete.")
-            pipeline_task.cancel()
-            try:
-                await pipeline_task
-            except asyncio.CancelledError:
-                pass
-
-        # If pipeline finished first, properly exit the app before cancelling the task
-        if pipeline_task in done and not app_task.done():
-            if not params.get("no_exit", False):
-                app.exit()
-
-            try:
-                await app_task
-            except asyncio.CancelledError:
-                pass
+        """
+        Run the given pipeline inside the FullDisplayApp, relying on Textual's
+        own lifecycle management (workers, timers, shutdown) rather than
+        juggling asyncio tasks externally.
+        """
+        app = FullDisplayApp(pipeline=pipeline, params=params)
+        await app.run_async()

--- a/src/dataset_foundry/displays/full/full_display_app.py
+++ b/src/dataset_foundry/displays/full/full_display_app.py
@@ -1,10 +1,13 @@
+import asyncio
 import logging
+from typing import Any
 
 from textual import events
 from textual.app import App, ComposeResult
 from textual.containers import Horizontal, Vertical
 from textual.widgets import ListView, Tab, Tabs
 
+from ...core.pipeline import Pipeline
 from ...core.pipeline_service import pipeline_service
 from ...displays.core.console_service import console_service
 from .widgets.console_log_view import ConsoleLogView
@@ -33,8 +36,13 @@ class FullDisplayApp(App):
     ItemLogView { width: 80%; }
     """
 
-    def __init__(self):
+    def __init__(self, pipeline: Pipeline, params: dict[str, Any]):
         super().__init__()
+        self._pipeline = pipeline
+        self._params = params
+        self._pipeline_worker = None
+        self._is_quitting = False
+
         self.app.begin_capture_print(self, stdout=True, stderr=True)
         self.log_view = ItemLogView()
         self.console_view = ConsoleLogView()
@@ -65,6 +73,12 @@ class FullDisplayApp(App):
 
         pipeline_service.subscribe("pipeline_started", {}, self._on_pipeline_started)
 
+        self._pipeline_worker = self.run_worker(
+            self._run_pipeline(),
+            name="pipeline-runner",
+            exit_on_error=True,
+        )
+
     def on_list_view_selected(self, event: ListView.Selected):
         # Only handle selections from the item tabs list
         source_list = event.list_view
@@ -85,6 +99,59 @@ class FullDisplayApp(App):
         #       switch to the tab if it is actually active. [fastfedora 10.Oct.25]
         if "-active" in event.tab.classes:
             self._switch_tab(event.tab.id)
+
+    async def _run_pipeline(self) -> None:
+        """
+        Run the configured pipeline in the background.
+
+        When the pipeline completes, exit the app unless `no_exit` was requested.
+        """
+        try:
+            await self._pipeline.run(params=self._params)
+        except asyncio.CancelledError:
+            # Expected when the user quits while the pipeline is still running. Let pipeline cleanup
+            # complete via its own try/finally, then fall through to the exit logic below without
+            # re-raising.
+            pass
+        finally:
+            if self._is_quitting or not self._params.get("no_exit", False):
+                self.exit()
+
+    def _cancel_pipeline(self, delay_seconds: float = 0.1) -> None:
+        """
+        Cancel the pipeline worker if it is still running, after a short delay.
+
+        The delay gives Textual time to refresh the UI so the shutdown message is visible before any
+        potentially blocking cleanup work begins.
+        """
+        worker = self._pipeline_worker
+
+        async def _cancel_after_delay() -> None:
+            await asyncio.sleep(delay_seconds)
+            if worker is not None and not worker.is_finished and worker.is_running:
+                worker.cancel()
+
+        self.call_later(_cancel_after_delay)
+
+    async def action_quit(self) -> None:
+        """
+        When the user quits the UI while the pipeline worker is still running, show a cleanup
+        message and keep the UI visible until the pipeline has finished its own shutdown.
+        """
+        if self._is_quitting:
+            return
+
+        self._is_quitting = True
+
+        if self._pipeline_worker is not None and not self._pipeline_worker.is_finished:
+            console_service.append(
+                "\nShutting down Docker containers... Please wait for cleanup to complete."
+            )
+            self._select_tab("tab_console")
+            self._cancel_pipeline()
+            return
+
+        self.exit()
 
     def _select_tab(self, tab_id: str) -> None:
         top_tabs = self.query_one('#top_tabs')

--- a/tests/test_full_display.py
+++ b/tests/test_full_display.py
@@ -1,0 +1,49 @@
+import asyncio
+
+import pytest
+
+from dataset_foundry.core.pipeline import Pipeline
+from dataset_foundry.core.dataset import Dataset
+from dataset_foundry.displays.full.full_display import FullDisplay
+
+
+class _DummyPipeline(Pipeline):
+    async def execute(self, dataset: Dataset, context):
+        # Minimal no-op pipeline body for integration testing the display.
+        return dataset
+
+
+@pytest.mark.asyncio
+async def test_full_display_runs_pipeline_and_exits():
+    """
+    FullDisplay.run_pipeline should run the pipeline to completion and exit
+    the Textual app cleanly when no_exit is False.
+    """
+    display = FullDisplay()
+    pipeline = _DummyPipeline(name="dummy")
+
+    # We expect this to complete without hanging or raising.
+    await asyncio.wait_for(
+        display.run_pipeline(pipeline, params={"no_exit": False}),
+        timeout=5,
+    )
+
+
+@pytest.mark.asyncio
+async def test_full_display_respects_no_exit_flag():
+    """
+    When no_exit is True, FullDisplay.run_pipeline should still return to the
+    caller (so the CLI can continue), even though the app itself keeps the
+    UI running until the user exits it.
+    """
+    display = FullDisplay()
+    pipeline = _DummyPipeline(name="dummy")
+
+    # For now we simply assert that the call completes. If Textual changes
+    # semantics around no_exit in the future, this test documents the current
+    # expectation that run_pipeline still returns.
+    await asyncio.wait_for(
+        display.run_pipeline(pipeline, params={"no_exit": True}),
+        timeout=5,
+    )
+

--- a/uv.lock
+++ b/uv.lock
@@ -667,9 +667,6 @@ wheels = [
 linkify = [
     { name = "linkify-it-py" },
 ]
-plugins = [
-    { name = "mdit-py-plugins" },
-]
 
 [[package]]
 name = "mdit-py-plugins"
@@ -1080,15 +1077,15 @@ wheels = [
 
 [[package]]
 name = "rich"
-version = "14.1.0"
+version = "14.3.2"
 source = { registry = "https://pypi.org/simple" }
 dependencies = [
     { name = "markdown-it-py" },
     { name = "pygments" },
 ]
-sdist = { url = "https://files.pythonhosted.org/packages/fe/75/af448d8e52bf1d8fa6a9d089ca6c07ff4453d86c65c145d0a300bb073b9b/rich-14.1.0.tar.gz", hash = "sha256:e497a48b844b0320d45007cdebfeaeed8db2a4f4bcf49f15e455cfc4af11eaa8", size = 224441 }
+sdist = { url = "https://files.pythonhosted.org/packages/74/99/a4cab2acbb884f80e558b0771e97e21e939c5dfb460f488d19df485e8298/rich-14.3.2.tar.gz", hash = "sha256:e712f11c1a562a11843306f5ed999475f09ac31ffb64281f73ab29ffdda8b3b8", size = 230143 }
 wheels = [
-    { url = "https://files.pythonhosted.org/packages/e3/30/3c4d035596d3cf444529e0b2953ad0466f6049528a879d27534700580395/rich-14.1.0-py3-none-any.whl", hash = "sha256:536f5f1785986d6dbdea3c75205c473f970777b4a0d6c6dd1b696aa05a3fa04f", size = 243368 },
+    { url = "https://files.pythonhosted.org/packages/ef/45/615f5babd880b4bd7d405cc0dc348234c5ffb6ed1ea33e152ede08b2072d/rich-14.3.2-py3-none-any.whl", hash = "sha256:08e67c3e90884651da3239ea668222d19bea7b589149d8014a21c633420dbb69", size = 309963 },
 ]
 
 [[package]]
@@ -1154,18 +1151,19 @@ wheels = [
 
 [[package]]
 name = "textual"
-version = "6.2.0"
+version = "7.5.0"
 source = { registry = "https://pypi.org/simple" }
 dependencies = [
-    { name = "markdown-it-py", extra = ["linkify", "plugins"] },
+    { name = "markdown-it-py", extra = ["linkify"] },
+    { name = "mdit-py-plugins" },
     { name = "platformdirs" },
     { name = "pygments" },
     { name = "rich" },
     { name = "typing-extensions" },
 ]
-sdist = { url = "https://files.pythonhosted.org/packages/18/e6/5b3aa6cc30a40246af587f3802f219f326981491a1a6b0623f07f0c4029f/textual-6.2.0.tar.gz", hash = "sha256:1561aeea3a6e9d8fa7bc3e2fcb2bb1d0c7a04e2661c0bb9fa5021cc9f1e905da", size = 1570354 }
+sdist = { url = "https://files.pythonhosted.org/packages/9f/38/7d169a765993efde5095c70a668bf4f5831bb7ac099e932f2783e9b71abf/textual-7.5.0.tar.gz", hash = "sha256:c730cba1e3d704e8f1ca915b6a3af01451e3bca380114baacf6abf87e9dac8b6", size = 1592319 }
 wheels = [
-    { url = "https://files.pythonhosted.org/packages/ca/97/1e6fad473147f825b1d3bec807cbf34c0c24aa6b61478df8d630cc664a44/textual-6.2.0-py3-none-any.whl", hash = "sha256:d9bb3b997a8a37687faeb0201978e7b7baf0e4644f39468f34a7bbad659bbbae", size = 710628 },
+    { url = "https://files.pythonhosted.org/packages/9c/78/96ddb99933e11d91bc6e05edae23d2687e44213066bcbaca338898c73c47/textual-7.5.0-py3-none-any.whl", hash = "sha256:849dfee9d705eab3b2d07b33152b7bd74fb1f5056e002873cc448bce500c6374", size = 718164 },
 ]
 
 [[package]]


### PR DESCRIPTION
Fix an error that was occurring when the Textual app was exiting. See the error below.

The issue was that the pipeline worker was not being managed by the Textual app itself. This PR refactors the app code so that the architecture is correct, which prevents this error from occurring.

```bash
> dataset-foundry examples/refactorable_code/generate_scenarios/pipeline.py dataset1b --num-samples=2         13:30:25
Traceback (most recent call last):
  File "/Users/trevor/Dev/ai/pivotal/dataset_foundry/.venv/bin/dataset-foundry", line 10, in <module>
    sys.exit(main())
             ^^^^^^
  File "/Users/trevor/Dev/ai/pivotal/dataset_foundry/src/dataset_foundry/cli/main.py", line 161, in main
    asyncio.run(main_cli())
  File "/opt/homebrew/Cellar/python@3.12/3.12.10_1/Frameworks/Python.framework/Versions/3.12/lib/python3.12/asyncio/runners.py", line 195, in run
    return runner.run(main)
           ^^^^^^^^^^^^^^^^
  File "/opt/homebrew/Cellar/python@3.12/3.12.10_1/Frameworks/Python.framework/Versions/3.12/lib/python3.12/asyncio/runners.py", line 118, in run
    return self._loop.run_until_complete(task)
           ^^^^^^^^^^^^^^^^^^^^^^^^^^^^^^^^^^^
  File "/opt/homebrew/Cellar/python@3.12/3.12.10_1/Frameworks/Python.framework/Versions/3.12/lib/python3.12/asyncio/base_events.py", line 691, in run_until_complete
    return future.result()
           ^^^^^^^^^^^^^^^
  File "/Users/trevor/Dev/ai/pivotal/dataset_foundry/src/dataset_foundry/cli/main.py", line 149, in main_cli
    await display.run_pipeline(module.pipeline, params={ **args, **pipeline_parameters })
  File "/Users/trevor/Dev/ai/pivotal/dataset_foundry/src/dataset_foundry/displays/full/full_display.py", line 43, in run_pipeline
    await app_task
  File "/Users/trevor/Dev/ai/pivotal/dataset_foundry/src/dataset_foundry/displays/full/full_display.py", line 19, in run_app_task
    await app.run_async()
  File "/Users/trevor/Dev/ai/pivotal/dataset_foundry/.venv/lib/python3.12/site-packages/textual/app.py", line 2201, in run_async
    await asyncio.shield(app._shutdown())
  File "/Users/trevor/Dev/ai/pivotal/dataset_foundry/.venv/lib/python3.12/site-packages/textual/app.py", line 3596, in _shutdown
    await self._close_all()
  File "/Users/trevor/Dev/ai/pivotal/dataset_foundry/.venv/lib/python3.12/site-packages/textual/app.py", line 3578, in _close_all
    await self._prune(stack_screen)
  File "/Users/trevor/Dev/ai/pivotal/dataset_foundry/.venv/lib/python3.12/site-packages/textual/await_remove.py", line 43, in await_prune
    await gather(*tasks)
  File "/Users/trevor/Dev/ai/pivotal/dataset_foundry/.venv/lib/python3.12/site-packages/textual/message_pump.py", line 573, in _process_messages
    await self._message_loop_exit()
  File "/Users/trevor/Dev/ai/pivotal/dataset_foundry/.venv/lib/python3.12/site-packages/textual/screen.py", line 1248, in _message_loop_exit
    await super()._message_loop_exit()
  File "/Users/trevor/Dev/ai/pivotal/dataset_foundry/.venv/lib/python3.12/site-packages/textual/widget.py", line 4377, in _message_loop_exit
    await gather(*[node._task for node in children if node._task is not None])
  File "/Users/trevor/Dev/ai/pivotal/dataset_foundry/.venv/lib/python3.12/site-packages/textual/message_pump.py", line 573, in _process_messages
    await self._message_loop_exit()
  File "/Users/trevor/Dev/ai/pivotal/dataset_foundry/.venv/lib/python3.12/site-packages/textual/widget.py", line 4377, in _message_loop_exit
    await gather(*[node._task for node in children if node._task is not None])
  File "/Users/trevor/Dev/ai/pivotal/dataset_foundry/.venv/lib/python3.12/site-packages/textual/message_pump.py", line 569, in _process_messages
    await Timer._stop_all(self._timers)
  File "/Users/trevor/Dev/ai/pivotal/dataset_foundry/.venv/lib/python3.12/site-packages/textual/timer.py", line 125, in _stop_all
    await gather(*[stop_timer(timer) for timer in list(timers)])
  File "/Users/trevor/Dev/ai/pivotal/dataset_foundry/.venv/lib/python3.12/site-packages/textual/timer.py", line 120, in stop_timer
    await timer._task
LookupError: <ContextVar name='active_app' at 0x1146b6200>
```