### PR TITLE
v0.3.0 Release Candidate 1

### DIFF
--- a/examples/refactorable_code/generate_repo_from_spec_with_swe_agent/pipeline.py
+++ b/examples/refactorable_code/generate_repo_from_spec_with_swe_agent/pipeline.py
@@ -8,7 +8,7 @@ from dataset_foundry.actions.item.save_item import save_item
 from dataset_foundry.core.key import Key
 from dataset_foundry.core.template import Template
 from dataset_foundry.core.item_pipeline import ItemPipeline
-from dataset_foundry.utils.item import omit
+from dataset_foundry.utils.collections.omit import omit
 
 pipeline = ItemPipeline(
     name="generate_repo_from_spec_with_swe_agent",

--- a/src/dataset_foundry/actions/item/run_unit_tests.py
+++ b/src/dataset_foundry/actions/item/run_unit_tests.py
@@ -1,22 +1,31 @@
 import logging
-from typing import Callable, Union, Optional, List
+import re
+from typing import Callable, Union, Optional
 from pathlib import Path
 
 from ...core.context import Context
 from ...core.dataset_item import DatasetItem
 from ...core.key import Key
+from ...types.command_result import CommandResult
+from ...types.unit_test_result import UnitTestResult
+
 from ...types.item_action import ItemAction
 from ...utils.params.resolve_item_value import resolve_item_value
 from ...utils.unit_tests.run_python_unit_tests import run_python_unit_tests
 from ...utils.unit_tests.parse_python_unit_test_results import parse_python_unit_test_results
-from ...utils.docker.sandbox_runner import SandboxRunner
+from ...utils.docker.sandbox_runner import SandboxResult, SandboxRunner
 
 logger = logging.getLogger(__name__)
+
+SETUP_START = "::setup:start::"
+SETUP_END_PATTERN = re.compile(r"::setup:end:(\d+)::")
+
 
 def run_unit_tests(
         filename: Union[Callable,Key,str],
         dir: Union[Callable,Key,str] = Key("context.input_dir"),
         property: Union[Callable,Key,str] = "test_result",
+        setup_property: Union[Callable,Key,str] = "setup_result",
         sandbox: Optional[Union[Callable,Key,str]] = None,
         stream_logs: Union[Callable,Key,bool] = False,
         timeout: Union[Callable,Key,int] = 300,
@@ -25,6 +34,7 @@ def run_unit_tests(
         resolved_filename = resolve_item_value(filename, item, context, required_as="filename")
         resolved_dir = resolve_item_value(dir, item, context, required_as="dir")
         resolved_property = resolve_item_value(property, item, context, required_as="property")
+        resolved_setup_property = resolve_item_value(setup_property, item, context)
         resolved_sandbox = resolve_item_value(sandbox, item, context)
         resolved_stream_logs = resolve_item_value(stream_logs, item, context)
         resolved_timeout = resolve_item_value(timeout, item, context)
@@ -45,16 +55,92 @@ def run_unit_tests(
                 timeout=resolved_timeout,
                 stream_logs=resolved_stream_logs
             )
+            pytest_result, setup_result = _parse_sandbox_result(sandbox_result)
 
-            result = parse_python_unit_test_results(sandbox_result)
-            result.command = command
+            if pytest_result.returncode is not None:
+                sandbox_result.stdout = pytest_result.stdout
+                sandbox_result.stderr = pytest_result.stderr
+
+                result = parse_python_unit_test_results(sandbox_result)
+                result.command = command
+            else:
+                result = UnitTestResult(
+                    command=command,
+                    returncode=None,
+                    num_passed=0,
+                    num_failed=0,
+                    stdout=pytest_result.stdout,
+                    stderr=pytest_result.stderr
+                )
         else:
             # Run tests locally
             result = run_python_unit_tests(Path(resolved_dir) / resolved_filename)
 
         item.push({ resolved_property: result }, run_unit_tests)
 
+        if setup_result is not None and resolved_setup_property:
+            item.push({ resolved_setup_property: setup_result }, run_unit_tests)
+
     return run_unit_tests_action
 
 
+def _parse_sandbox_result(sandbox_result: SandboxResult) -> tuple[CommandResult, CommandResult]:
+    """
+    Parse sandbox result into pytest and setup command results.
 
+    Looks for ::setup:start:: and ::setup:end:N:: in stdout and stderr. Content between those
+    markers is the setup result; everything after the end marker is treated as pytest output. If no
+    setup markers are present, setup is empty/success and all output is pytest.
+    """
+    pytest_stdout, setup_stdout, setup_stdout_code = _split_stream(sandbox_result.stdout)
+    pytest_stderr, setup_stderr, setup_stderr_code = _split_stream(sandbox_result.stderr)
+
+    setup_returncode = setup_stdout_code if setup_stdout_code is not None else setup_stderr_code
+    pytest_returncode = sandbox_result.exit_code
+
+    # End tag for setup not found or no pytest output indicates setup failed and pytest never ran
+    if setup_returncode == -1 or (pytest_stdout == "" and pytest_stderr == ""):
+        setup_returncode = sandbox_result.exit_code
+        pytest_returncode = None
+
+    return (
+        CommandResult(
+            command=[],
+            returncode=pytest_returncode,
+            stdout=pytest_stdout,
+            stderr=pytest_stderr,
+        ),
+        CommandResult(
+            command=[],
+            returncode=setup_returncode,
+            stdout=setup_stdout,
+            stderr=setup_stderr,
+        ),
+    )
+
+
+def _split_stream(output: str) -> tuple[str, str, Optional[int]]:
+    """
+    Split the output into pytest and setup sections.
+
+    Args:
+        output: The output to split
+
+    Returns:
+        A tuple containing the pytest content, the setup content, and the setup exit code
+    """
+    start_idx = output.find(SETUP_START)
+    if start_idx == -1:
+        # No start marker: treat all output as pytest content
+        return output.strip("\n"), "", None
+
+    content_after_start = output[start_idx + len(SETUP_START) :]
+    end_match = SETUP_END_PATTERN.search(content_after_start)
+    if not end_match:
+        # Start marker present but no end marker: treat everything after start as setup content
+        return "", content_after_start.strip("\n"), -1
+
+    setup_content = content_after_start[: end_match.start()].strip("\n")
+    pytest_content = content_after_start[end_match.end() :].strip("\n")
+
+    return pytest_content, setup_content, int(end_match.group(1))

--- a/src/dataset_foundry/configs/agents/claude_code/Dockerfile
+++ b/src/dataset_foundry/configs/agents/claude_code/Dockerfile
@@ -72,10 +72,15 @@ ENV PATH=$PATH:/usr/local/share/npm-global/bin
 # Install Claude
 RUN npm install -g @anthropic-ai/claude-code
 
-# Copy firewall scripts and config file
-COPY firewall/* /usr/local/bin/firewall/
+# Copy firewall scripts and config file. The Docker build context is `configs` (see `sandbox.yml`),
+# so these paths are relative to `src/dataset_foundry/configs`.
+COPY agents/claude_code/firewall/* /usr/local/bin/firewall/
 
 USER root
+
+# Copy the shared setup-repo script
+COPY shared/setup-repo.sh /usr/local/bin/setup-repo.sh
+RUN chmod +x /usr/local/bin/setup-repo.sh
 
 RUN chmod +x /usr/local/bin/firewall/init.sh && \
   chmod +x /usr/local/bin/firewall/allow-domains.sh && \
@@ -84,5 +89,5 @@ RUN chmod +x /usr/local/bin/firewall/init.sh && \
 
 USER node
 
-# Initialize firewall and then execute the command passed to the container
-ENTRYPOINT ["sh", "-c", "sudo /usr/local/bin/firewall/init.sh && exec \"$@\"", "--"]
+# Initialize firewall, run repo setup and then execute the command passed to the container
+ENTRYPOINT ["sh", "-c", "sudo /usr/local/bin/firewall/init.sh && /usr/local/bin/setup-repo.sh \"$REPO_DIR\" && exec \"$@\"", "--"]

--- a/src/dataset_foundry/configs/agents/claude_code/Dockerfile
+++ b/src/dataset_foundry/configs/agents/claude_code/Dockerfile
@@ -7,6 +7,9 @@ ENV TZ="$TZ"
 ENV PYTHONUNBUFFERED="1"
 ENV PYTHONDONTWRITEBYTECODE="1"
 
+# Allow Python packages to be installed without a virtual environment
+ENV PIP_BREAK_SYSTEM_PACKAGES="1"
+
 # Install basic development tools and iptables/ipset
 RUN set -eu; \
   apt-get update; \

--- a/src/dataset_foundry/configs/agents/claude_code/agent.yml
+++ b/src/dataset_foundry/configs/agents/claude_code/agent.yml
@@ -1,6 +1,9 @@
 container:
   image: "claude-code-agent:latest"
   build:
+    # Use `configs` as the Docker build context so we can COPY files like `shared/setup-repo.sh`
+    context: ../..
+    dockerfile: agents/claude_code/Dockerfile
     args:
       TZ: "${TZ:-America/Los_Angeles}"
   cap_add:

--- a/src/dataset_foundry/configs/agents/codex/Dockerfile
+++ b/src/dataset_foundry/configs/agents/codex/Dockerfile
@@ -13,6 +13,9 @@ WORKDIR /workspace
 ENV LANG=en_US.UTF-8
 ENV PYTHONUNBUFFERED=1
 
+# Allow Python packages to be installed without a virtual environment
+ENV PIP_BREAK_SYSTEM_PACKAGES="1"
+
 # Copy the setup-repo script. The Docker build context is `configs` (see `sandbox.yml`), so these
 # paths are relative to `src/dataset_foundry/configs`.
 COPY shared/setup-repo.sh /usr/local/bin/setup-repo.sh

--- a/src/dataset_foundry/configs/agents/codex/Dockerfile
+++ b/src/dataset_foundry/configs/agents/codex/Dockerfile
@@ -6,7 +6,12 @@ RUN apt-get update && \
     apt-get install -y curl git build-essential software-properties-common && \
     rm -rf /var/lib/apt/lists/*
 
-RUN brew install codex
+# brew expects to run as a non-root user
+USER linuxbrew
+
+ENV HOMEBREW_NO_AUTO_UPDATE=1
+
+RUN brew install --cask codex
 
 WORKDIR /workspace
 

--- a/src/dataset_foundry/configs/agents/codex/Dockerfile
+++ b/src/dataset_foundry/configs/agents/codex/Dockerfile
@@ -13,5 +13,10 @@ WORKDIR /workspace
 ENV LANG=en_US.UTF-8
 ENV PYTHONUNBUFFERED=1
 
+# Copy the setup-repo script. The Docker build context is `configs` (see `sandbox.yml`), so these
+# paths are relative to `src/dataset_foundry/configs`.
+COPY shared/setup-repo.sh /usr/local/bin/setup-repo.sh
+RUN chmod +x /usr/local/bin/setup-repo.sh
+
 # Default command (will be overridden by entrypoint)
-ENTRYPOINT ["sh", "-c", "exec \"$@\"", "--"]
+ENTRYPOINT ["sh", "-c", "/usr/local/bin/setup-repo.sh \"$REPO_DIR\" && exec \"$@\"", "--"]

--- a/src/dataset_foundry/configs/agents/codex/agent.yml
+++ b/src/dataset_foundry/configs/agents/codex/agent.yml
@@ -1,5 +1,9 @@
 container:
   image: "codex-agent:latest"
+  build:
+    # Use `configs` as the Docker build context so we can COPY files like `shared/setup-repo.sh`
+    context: ../..
+    dockerfile: agents/codex/Dockerfile
   environment:
     OPENAI_API_KEY: "${OPENAI_API_KEY}"
     # Set in `agent_runner` to be model string from `CODEX_MODEL` or `DF_MODEL`

--- a/src/dataset_foundry/configs/sandboxes/python/Dockerfile
+++ b/src/dataset_foundry/configs/sandboxes/python/Dockerfile
@@ -4,6 +4,9 @@ FROM python:3.11-slim
 ENV PYTHONUNBUFFERED="1"
 ENV PYTHONDONTWRITEBYTECODE="1"
 
+# Allow Python packages to be installed without a virtual environment
+ENV PIP_BREAK_SYSTEM_PACKAGES="1"
+
 # Prevent pip from checking for new versions & cluttering up stderr with warnings
 ENV PIP_DISABLE_PIP_VERSION_CHECK="1"
 

--- a/src/dataset_foundry/configs/sandboxes/python/Dockerfile
+++ b/src/dataset_foundry/configs/sandboxes/python/Dockerfile
@@ -28,8 +28,11 @@ RUN pip install --no-cache-dir \
 # Create a non-root user for security
 RUN useradd --create-home --shell /bin/bash guest
 
-# Copy the init script
-COPY init.sh /usr/local/bin/init.sh
+# Copy the setup-repo and init scripts. The Docker build context is `configs` (see `sandbox.yml`),
+# so these paths are relative to `src/dataset_foundry/configs`.
+COPY shared/setup-repo.sh /usr/local/bin/setup-repo.sh
+RUN chmod +x /usr/local/bin/setup-repo.sh
+COPY sandboxes/python/init.sh /usr/local/bin/init.sh
 RUN chmod +x /usr/local/bin/init.sh
 
 # Change ownership of workspace directory to guest user

--- a/src/dataset_foundry/configs/sandboxes/python/init.sh
+++ b/src/dataset_foundry/configs/sandboxes/python/init.sh
@@ -2,11 +2,4 @@
 # Add local bin directory to PATH to quiet pip warning
 export PATH="$HOME/.local/bin:$PATH"
 
-# Install requirements.txt if it exists in the current working directory
-if [ -f "requirements.txt" ]; then
-    echo "Installing dependencies from requirements.txt..."
-    pip install --user -r requirements.txt
-    echo "Dependencies installed successfully."
-else
-    echo "No requirements.txt found in working directory, skipping dependency installation."
-fi
+. /usr/local/bin/setup-repo.sh "$PWD"

--- a/src/dataset_foundry/configs/sandboxes/python/sandbox.yml
+++ b/src/dataset_foundry/configs/sandboxes/python/sandbox.yml
@@ -2,7 +2,8 @@ name: python-sandbox
 container:
   image: python-sandbox:latest
   build:
-    context: .
-    dockerfile: Dockerfile
+    # Use `configs` as the Docker build context so we can COPY files like `shared/setup-repo.sh`
+    context: ../..
+    dockerfile: sandboxes/python/Dockerfile
   working_dir: /workspace
   command: ["python"]

--- a/src/dataset_foundry/configs/shared/setup-repo.sh
+++ b/src/dataset_foundry/configs/shared/setup-repo.sh
@@ -1,7 +1,10 @@
 #!/bin/bash
 # Install any dependencies or run any setup scripts (which install dependencies & seed databases),
+# wrapping the output in ::setup:start:: and ::setup:end:: tags for both stdout and stderr.
 
 dir="${1:-.}"
+
+echo "::setup:start::" | tee /dev/stderr
 
 if [ -f "$dir/script/setup" ]; then
     echo "Running setup script..."
@@ -16,3 +19,8 @@ elif [ -f "$dir/pyproject.toml" ]; then
 else
     echo "Skipping setup and dependency installation. No setup details found in working directory."
 fi
+
+setup_status=$?
+
+echo "::setup:end:${setup_status}::" | tee /dev/stderr
+exit $setup_status

--- a/src/dataset_foundry/configs/shared/setup-repo.sh
+++ b/src/dataset_foundry/configs/shared/setup-repo.sh
@@ -1,0 +1,18 @@
+#!/bin/bash
+# Install any dependencies or run any setup scripts (which install dependencies & seed databases),
+
+dir="${1:-.}"
+
+if [ -f "$dir/script/setup" ]; then
+    echo "Running setup script..."
+    chmod u+x "$dir"/script/*
+    "$dir/script/setup"
+elif [ -f "$dir/requirements.txt" ]; then
+    echo "Installing dependencies from requirements.txt..."
+    pip install -r "$dir/requirements.txt"
+elif [ -f "$dir/pyproject.toml" ]; then
+    echo "Installing dependencies from pyproject.toml..."
+    pip install -e "$dir"
+else
+    echo "Skipping setup and dependency installation. No setup details found in working directory."
+fi

--- a/src/dataset_foundry/configs/shared/setup-repo.sh
+++ b/src/dataset_foundry/configs/shared/setup-repo.sh
@@ -6,6 +6,12 @@ dir="${1:-.}"
 
 echo "::setup:start::" | tee /dev/stderr
 
+if [ -n "${SKIP_REPO_SETUP}" ]; then
+    echo "Skipping repo setup because SKIP_REPO_SETUP is set"
+    echo "::setup:end:0::" | tee /dev/stderr
+    exit 0
+fi
+
 if [ -f "$dir/script/setup" ]; then
     echo "Running setup script..."
     chmod u+x "$dir"/script/*

--- a/src/dataset_foundry/types/command_result.py
+++ b/src/dataset_foundry/types/command_result.py
@@ -1,0 +1,30 @@
+import logging
+from pydantic import BaseModel
+from typing import Any, List
+
+logger = logging.getLogger(__name__)
+
+
+class CommandResult(BaseModel):
+    command: List[Any]
+    returncode: int | None
+    stdout: str
+    stderr: str = ""
+
+    @property
+    def success(self) -> bool:
+        return self.returncode == 0
+
+    def __str__(self):
+        """
+        Return a string representation of the command result. If debugging is enabled, include
+        the stdout and stderr in the string.
+        """
+        debugging = logger.isEnabledFor(logging.DEBUG)
+        include_error = debugging or not self.success
+        status = "SUCCESS" if self.success else "FAILED"
+        stderr = f", stderr: {self.stderr}" if self.stderr else ""
+        stdout = f", stdout: {self.stdout}" if debugging and self.stdout else ""
+        error = f" (code: {self.returncode}{stderr}{stdout})" if include_error else ""
+
+        return f"{status}{error}"

--- a/src/dataset_foundry/types/unit_test_result.py
+++ b/src/dataset_foundry/types/unit_test_result.py
@@ -1,17 +1,13 @@
 import logging
-from pydantic import BaseModel
-from typing import Any, List
+
+from .command_result import CommandResult
 
 logger = logging.getLogger(__name__)
 
 
-class UnitTestResult(BaseModel):
-    command: List[Any]
+class UnitTestResult(CommandResult):
     num_passed: int
     num_failed: int
-    returncode: int
-    stdout: str
-    stderr: str
 
     @property
     def total_tests(self) -> int:

--- a/src/dataset_foundry/utils/docker/agent_runner.py
+++ b/src/dataset_foundry/utils/docker/agent_runner.py
@@ -157,6 +157,7 @@ class AgentRunner(BaseRunner):
         self._prepare_environment_config(config, {
             "ITEM_ID": inputs.item_id,
             "OUTPUT_DIR": f"{working_dir}/output",
+            "REPO_DIR": f"{working_dir}/repo",
             "CONTEXT_DATA": json.dumps(inputs.context_data),
         })
 

--- a/src/dataset_foundry/utils/docker/agent_runner.py
+++ b/src/dataset_foundry/utils/docker/agent_runner.py
@@ -31,6 +31,7 @@ class AgentInputs(BaseModel):
     item_id: str
     context_data: Dict[str, Any]
     repo_path: Optional[str] = None
+    skip_repo_setup: bool = False
 
 
 class AgentResult(BaseModel):
@@ -154,12 +155,15 @@ class AgentRunner(BaseRunner):
                 read_only=True
             ),
         ])
-        self._prepare_environment_config(config, {
+        environment = {
             "ITEM_ID": inputs.item_id,
             "OUTPUT_DIR": f"{working_dir}/output",
             "REPO_DIR": f"{working_dir}/repo",
             "CONTEXT_DATA": json.dumps(inputs.context_data),
-        })
+        }
+        if inputs.skip_repo_setup:
+            environment["SKIP_REPO_SETUP"] = "1"
+        self._prepare_environment_config(config, environment)
 
         return config
 

--- a/src/dataset_foundry/utils/params/resolve_value.py
+++ b/src/dataset_foundry/utils/params/resolve_value.py
@@ -21,7 +21,7 @@ def resolve_value(
     if hasattr(object, 'id'):
         variables['id'] = object.id
 
-    if value:
+    if value is not None:
         if callable(value):
             arg_count = value.__code__.co_argcount
             resolved_value = value(object) if arg_count == 1 else value(object, context)


### PR DESCRIPTION
Fixes multiple issues with how repos are setup to ensure all of their dependencies are installed and all databases seeded before running tests or handing the repo to an agent to work on. Added a way to save repo setup results separate from test results, so pipelines can handle when the setup fails and tests can't run.

Also fixed a bug with resolving values set to a non-None falsey value. 

## Summary

### Enhancements
 - Introduced `setup_property` parameter to store setup results separately from test results in `run_unit_tests`.
 - Added `skip_repo_setup` parameter to `run_swe_agent` to prevent the setup scripts from running before handing the repo to the agent. Useful when asking the agent to analyze the raw repo.

### Bug Fixes
 - **Breaking: Corrected resolution of falsey non-None values ("", [], 0, False) when using the `set_item_property` action. Previously they resolved to `None`; now they resolve to the value provided**
 - Fixed duplicated and inconsistent repo setup behavior where repos were sometimes being set up twice during tests (if requirements.txt existed) and not at all during agent runs.
 - Ensured Python packages can install without a virtual machine by setting `PIP_BREAK_SYSTEM_PACKAGES`
 - Updated Codex installation to use the correct Homebrew cask location.
 - Reduced noise and improved speed by setting HOMEBREW_NO_AUTO_UPDATE=1.
 - Fixed import in example pipeline.

## Components

### Updated

#### Item Actions

`run_swe_agent`
: Added `skip_repo_setup` parameter to allow conditional repository initialization.

`run_unit_tests`
: Added `setup_property` parameter to specify which item property to save the setup results to.
