### PR TITLE
v0.4.0 Release Candidate 1

### DIFF
--- a/src/dataset_foundry/actions/dataset/generate_dataset.py
+++ b/src/dataset_foundry/actions/dataset/generate_dataset.py
@@ -82,6 +82,7 @@ def generate_dataset(
             contents = contents[:context['num_samples']]
 
         for i, content in enumerate(contents):
+            # TODO: Make this configurable, so we can set the ID to `scenarios` for the pipeline viewer
             item = DatasetItem(
                 f"{i+1:03d}",
                 { resolved_output_key: content } if resolved_output_key else content

--- a/src/dataset_foundry/actions/item/run_swe_agent.py
+++ b/src/dataset_foundry/actions/item/run_swe_agent.py
@@ -138,6 +138,8 @@ async def _prepare_agent_inputs(
         spec_file.write_text(str(spec))
 
     # Copy existing repo if provided
+    # TODO: This appears to be unused. The repo is mounted as a volume in the container. Consider
+    #       removing this. [fastfedora 25.Feb.26]
     if repo_path:
         repo_source = Path(repo_path)
         if repo_source.exists():

--- a/src/dataset_foundry/actions/item/set_item_metadata.py
+++ b/src/dataset_foundry/actions/item/set_item_metadata.py
@@ -14,14 +14,43 @@ def set_item_metadata(
     async def set_item_metadata_action(item: DatasetItem, context: Context):
         resolved_property = resolve_item_value(property, item, context, required_as="property")
 
-        metadata = {
-            "pipeline": get_pipeline_metadata(context),
-            "model": context.model.info,
-            "created_at": datetime.now().isoformat(),
-        }
+        run_at = datetime.now().isoformat()
+        metadata = item.data.get("metadata", {})
+        metadata["version"] = 2
+
+        if "created_at" in metadata:
+            # Convert old metadata format to new format
+            if "pipeline" in metadata and "model" in metadata:
+                metadata.setdefault("initial", {
+                    "pipeline": metadata["pipeline"],
+                    "model": metadata["model"],
+                    "run_at": metadata["created_at"],
+                })
+                del metadata["pipeline"]
+                del metadata["model"]
+
+                if "swe_agent" in metadata:
+                    metadata["initial"]["swe_agent"] = metadata["swe_agent"]
+                    del metadata["swe_agent"]
+
+            # Add edit to metadata
+            metadata["updated_at"] = run_at
+            metadata.setdefault("edits", []).append({
+                "pipeline": get_pipeline_metadata(context),
+                "model": context.model.info,
+                "run_at": run_at,
+            })
+
+        else:
+            metadata["created_at"] = run_at
+            metadata.setdefault("initial", {
+                "pipeline": get_pipeline_metadata(context),
+                "model": context.model.info,
+                "run_at": run_at,
+            })
 
         item.push({
-            resolved_property: metadata
-        }, set_item_metadata);
+            resolved_property: metadata,
+        }, set_item_metadata)
 
     return set_item_metadata_action

--- a/src/dataset_foundry/actions/item/set_item_property.py
+++ b/src/dataset_foundry/actions/item/set_item_property.py
@@ -14,6 +14,8 @@ def set_item_property(
         resolved_key = resolve_item_value(key, item, context, required_as="key")
         resolved_value = resolve_item_value(value, item, context)
 
+        # TODO: Think about whether we should delete the key if the value is None, and if so, how.
+        #       we might do that with history tracking. [fastfedora 5.Aug.25]
         item.push({
             resolved_key: resolved_value
         }, set_item_property);

--- a/src/dataset_foundry/configs/agents/claude_code/Dockerfile
+++ b/src/dataset_foundry/configs/agents/claude_code/Dockerfile
@@ -93,4 +93,8 @@ RUN chmod +x /usr/local/bin/firewall/init.sh && \
 USER node
 
 # Initialize firewall, run repo setup and then execute the command passed to the container
-ENTRYPOINT ["sh", "-c", "sudo /usr/local/bin/firewall/init.sh && /usr/local/bin/setup-repo.sh \"$REPO_DIR\" && exec \"$@\"", "--"]
+# NOTE: Temporarily disabling firewall initialization, since some of the repo samples created for
+#       `full-repo-datasets` require internet access for testing. I'm not yet sure how to resolve
+#       that with giving Claude Code full access to the internet. [fastfedora 25.Feb.26]
+# ENTRYPOINT ["sh", "-c", "sudo /usr/local/bin/firewall/init.sh && /usr/local/bin/setup-repo.sh \"$REPO_DIR\" && exec \"$@\"", "--"]
+ENTRYPOINT ["sh", "-c", "/usr/local/bin/setup-repo.sh \"$REPO_DIR\" && exec \"$@\"", "--"]

--- a/src/dataset_foundry/configs/agents/claude_code/firewall/init.sh
+++ b/src/dataset_foundry/configs/agents/claude_code/firewall/init.sh
@@ -34,31 +34,7 @@ iptables -A OUTPUT -o lo -j ACCEPT
 # Create ipset with CIDR support
 ipset create allowed-domains hash:net
 
-# Fetch GitHub meta information and aggregate + add their IP ranges
-echo "Fetching GitHub IP ranges..."
-gh_ranges=$(curl -s https://api.github.com/meta)
-if [ -z "$gh_ranges" ]; then
-    echo "ERROR: Failed to fetch GitHub IP ranges"
-    exit 1
-fi
-
-if ! echo "$gh_ranges" | jq -e '.web and .api and .git' >/dev/null; then
-    echo "ERROR: GitHub API response missing required fields"
-    echo "$gh_ranges"
-    exit 1
-fi
-
-echo "Processing GitHub IPs..."
-while read -r cidr; do
-    if [[ ! "$cidr" =~ ^[0-9]{1,3}\.[0-9]{1,3}\.[0-9]{1,3}\.[0-9]{1,3}/[0-9]{1,2}$ ]]; then
-        echo "ERROR: Invalid CIDR range from GitHub meta: $cidr"
-        exit 1
-    fi
-    echo "Adding GitHub range $cidr"
-    ipset add allowed-domains "$cidr"
-done < <(echo "$gh_ranges" | jq -r '(.web + .api + .git)[]' | aggregate -q)
-
-# Resolve and add other allowed domains from external configuration
+# Resolve and add allowed domains from external configuration
 "${SCRIPT_DIR}/allow-domains.sh" "${SCRIPT_DIR}/firewall.yml"
 
 # Get host IP from default route
@@ -94,14 +70,6 @@ if curl --connect-timeout 5 https://example.com >/dev/null 2>&1; then
     exit 1
 else
     echo "Firewall verification passed - unable to reach https://example.com as expected"
-fi
-
-# Verify GitHub API access
-if ! curl --connect-timeout 5 https://api.github.com/zen >/dev/null 2>&1; then
-    echo "ERROR: Firewall verification failed - unable to reach https://api.github.com"
-    exit 1
-else
-    echo "Firewall verification passed - able to reach https://api.github.com as expected"
     echo "----------------------------------------------------------------"
     echo "SUCCESS: Firewall configured"
     echo "----------------------------------------------------------------"

--- a/src/dataset_foundry/configs/shared/setup-repo.sh
+++ b/src/dataset_foundry/configs/shared/setup-repo.sh
@@ -3,6 +3,7 @@
 # wrapping the output in ::setup:start:: and ::setup:end:: tags for both stdout and stderr.
 
 dir="${1:-.}"
+original_dir="$(pwd)"
 
 echo "::setup:start::" | tee /dev/stderr
 
@@ -12,21 +13,31 @@ if [ -n "${SKIP_REPO_SETUP}" ]; then
     exit 0
 fi
 
-if [ -f "$dir/script/setup" ]; then
+# Run all scripts from the repo directory; if no repo directory exists yet, exit with success
+cd "$dir" 2>/dev/null || {
+    echo "Skipping repo setup because no repo detected in ${dir}"
+    echo "::setup:end:0::" | tee /dev/stderr
+    exit 0
+}
+
+
+if [ -f "script/setup" ]; then
     echo "Running setup script..."
-    chmod u+x "$dir"/script/*
-    "$dir/script/setup"
-elif [ -f "$dir/requirements.txt" ]; then
+    chmod u+x script/*
+    ./script/setup
+elif [ -f "requirements.txt" ]; then
     echo "Installing dependencies from requirements.txt..."
-    pip install -r "$dir/requirements.txt"
-elif [ -f "$dir/pyproject.toml" ]; then
+    pip install -r requirements.txt
+elif [ -f "pyproject.toml" ]; then
     echo "Installing dependencies from pyproject.toml..."
-    pip install -e "$dir"
+    pip install -e .
 else
     echo "Skipping setup and dependency installation. No setup details found in working directory."
 fi
 
 setup_status=$?
+
+cd "$original_dir" || echo "Warning: failed to restore original directory $original_dir" >&2
 
 echo "::setup:end:${setup_status}::" | tee /dev/stderr
 exit $setup_status

--- a/src/dataset_foundry/utils/docker/agent_runner.py
+++ b/src/dataset_foundry/utils/docker/agent_runner.py
@@ -135,6 +135,9 @@ class AgentRunner(BaseRunner):
         os.environ["AGENT_MODEL"] = agent_model
 
         self._prepare_volumes_config(config, [
+            # TODO: Figure out how to exclude the `runs` directory from this mount, so the agent
+            #       doesn't waste time looking in these folders (i.e., make a configurable property
+            #       of ignored directories). [fastfedora 25.Feb.26]
             Mount(target=working_dir, source=str(output_dir), type="bind", read_only=False),
             Mount(
                 target=f"{inputs_dir}/prompt.md",

--- a/src/dataset_foundry/utils/docker/sandbox_runner.py
+++ b/src/dataset_foundry/utils/docker/sandbox_runner.py
@@ -105,6 +105,9 @@ class SandboxRunner(BaseRunner):
 
         working_dir = self._get_working_dir(config)
 
+        # TODO: Maybe use a volume mount that copies files into the container instead of a bind
+        #       mount so the sandbox runner isn't modifying the original sample unless we want it
+        #       to. [fastfedora 25.Feb.26]
         self._prepare_volumes_config(config, [
             Mount(target=working_dir, source=str(workspace_dir), type="bind", read_only=False)
         ])


### PR DESCRIPTION
Fixes setup issues for repos, rate-limiting errors from GitHub and firewall access problems. Upgrades the metadata to a new format to better track provenance for repo sample modifications.  

Upgrades to metadata format v2 include:

- `pipeline`, `model` and `swe_agent` moved under `initial` key along with a copy of the creation date renamed to `run_at`.
- Pipelines running after metadata exist add their metadata as a list under `edits` and add a top-level `updated_at` key.
- A top-level `version` key is set to 2.

## Summary

### Enhancements

 - Updated `set_item_metadata` to add pipeline & model metadata under `edits` if the metadata already exists (indicating a previous run created it).
 - Breaking: Updated `set_item_metadata` to upgrade data to the new data format.
 - Added TODO markers to clarify pending work and future improvements.

### Bug Fixes

 - Ensured repository setup scripts execute with the repository as the current working directory. Prevents failures when setup scripts invoke other scripts assuming repo-relative paths.
 - Removed GitHub-specific firewall rules that were triggering rate limiting failures. The agent does not access GitHub directly, so these rules were unnecessary.
 - Temporarily disabled firewall enforcement for Claude Code to allow tests requiring external network access to run successfully.
