### PR TITLE
Release Candidate 0.4.1 (closed in favor of 0.5.0 version)

### DIFF
--- a/.claude/settings.local.json
+++ b/.claude/settings.local.json
@@ -1,0 +1,9 @@
+{
+  "permissions": {
+    "allow": [
+      "Bash(git merge-base:*)",
+      "Bash(git log:*)",
+      "Bash(git diff:*)"
+    ]
+  }
+}

--- a/.claude/skills/pr-description/SKILL.md
+++ b/.claude/skills/pr-description/SKILL.md
@@ -1,0 +1,195 @@
+---
+name: pr-description
+description: Generate a pull request description from branch commits and diffs. Use this skill whenever the user asks to write, create, generate, or draft a PR description, pull request summary, PR body, or merge request description. Also trigger when the user says things like "describe this PR", "what should the PR say", "write up these changes", or "summarize this branch for a PR". Even casual phrases like "PR desc" or "write the PR" should trigger this skill.
+---
+
+# PR Description Generator
+
+Generate a structured pull request description by analyzing all commits on the current branch compared to the base branch.
+
+## Gathering context
+
+1. Determine the base branch. If the user provides one as an argument, use that. Otherwise default to `main`.
+2. Get the merge base: `git merge-base <base-branch> HEAD`
+3. Get all commits since the merge base with full messages: `git log --reverse --format="### %s%n%n%b" <merge-base>..HEAD`
+4. Get the full diff: `git diff <merge-base>..HEAD`
+5. Get the list of changed files grouped by status: `git diff --stat <merge-base>..HEAD`
+
+Read through the commits and diff carefully. Understand not just *what* changed but *why*—commit messages often explain motivation, and the diff reveals the actual behavioral changes.
+
+## Writing the description
+
+The description has three sections: a summary paragraph, a categorized summary, and an actions breakdown.
+
+### The summary paragraph
+
+Write 1-3 natural paragraphs at the top (no heading) that explain the overall motivation and purpose of the changes. This is the most important part—it should tell someone *why* this PR exists, not just catalog what it touches.
+
+Lead with specific, concrete names—action names, parameter names, the actual things that changed. Don't abstract them into vague categories like "new looping capabilities" when you can say "Adds `do_while_item` action." The reader should know exactly what's in this PR from the first sentence.
+
+Think about it from the perspective of a reviewer or someone reading the changelog: what problem was being solved? What was broken or missing before? If there are breaking changes, call them out here so they're impossible to miss.
+
+Don't start with "This PR..."—just lead with the substance. For example: "Adds `do_while_item` action and fixes several issues with Docker sandbox environments..." or "The caching layer was silently dropping entries when..."
+
+### The categorized summary
+
+```
+## Summary
+
+### Enhancements
+ - Description of each enhancement, being specific about parameter names and behaviors added.
+
+### Bug Fixes
+ - **Breaking: description here** (for fixes that change existing behavior)
+ - Description of each fix
+```
+
+Guidelines:
+- Only include `### Enhancements` or `### Bug Fixes` if there are items for that category. Skip empty categories entirely.
+- Do not include Documentation or Refactoring sections. Only include Enhancements and Bug Fixes. If a refactor changes observable behavior, list it as an enhancement.
+- Each bullet should be concise but specific—mention parameter names, function names, and concrete behavioral changes rather than vague descriptions.
+- For new actions or parameters with non-obvious behavior, explain the semantics. For example: "Unlike `while_item`, the condition is evaluated after the actions, so `iteration` is 1 on the first condition check."
+- Use parenthetical format for secondary identifiers: `--max-tokens` CLI option (`DF_MAX_TOKENS` for env) rather than `--max-tokens` / `DF_MAX_TOKENS`.
+- For bug fixes, describe outcomes rather than implementation details. Say "Both the full and log displays can now be cleanly exited" rather than "by raising `KeyboardInterrupt` from the signal handler."
+- Explain *why* something matters, not just what it does. Say "making it easier to see which parameters were actually used" rather than "for easier debugging."
+- Bold any breaking changes with the `**Breaking:**` prefix. A change is breaking if it alters existing behavior that consumers may depend on.
+
+### The actions breakdown
+
+This section only covers actions (the building blocks of pipelines). Other changes like CLI, infrastructure, or internal refactoring belong in the Summary section bullets, not here.
+
+```
+## Actions
+
+### Updated
+
+#### Item
+
+`action_name`
+: Description of what changed.
+
+#### Dataset
+
+`another_action`
+: Description of what changed.
+
+### Added
+
+#### Item
+
+`new_action`
+: What it does and why it was added.
+
+### Removed
+
+#### Item
+
+`removed_action`
+: Why it was removed.
+```
+
+Guidelines:
+- Only include actions—the functions defined in `actions/item/` and `actions/dataset/`. Do not include CLI changes, Docker infrastructure, utility modules, or other non-action code.
+- Group actions under `#### Item` or `#### Dataset` sub-headings based on whether they live in `actions/item/` or `actions/dataset/`.
+- Use the definition list format: backtick-wrapped name on its own line, then `: ` followed by the description on the next line.
+- Only include `### Updated`, `### Added`, or `### Removed` sections that have content. Skip empty ones.
+- Skip the entire `## Actions` section if no actions were changed.
+
+### The dependencies breakdown
+
+Place this section between Summary and Components. Check the diff for changes to dependency files (e.g., `pyproject.toml`, `uv.lock`, `package.json`, `requirements.txt`, `Cargo.toml`, `go.mod`, etc.) and list any dependency changes.
+
+```
+## Dependencies
+
+### New
+- `dependency-name` v0.0.0
+
+### Upgraded
+- `dependency-name` v0.0.0 -> v1.0.0
+
+### Removed
+- `dependency-name`
+```
+
+Guidelines:
+- Only include `### New`, `### Upgraded`, or `### Removed` subsections that have content.
+- Skip the entire `## Dependencies` section if there are no dependency changes.
+- Include the version for New and Upgraded dependencies. For Upgraded, show the old and new version with `->`.
+- For Removed dependencies, just the name is sufficient.
+
+## Output
+
+Output the full PR description as markdown. Do not wrap it in a code fence—just output the raw markdown text so the user can copy it directly.
+
+## Example
+
+Here's an example of a well-written PR description to calibrate tone and structure:
+
+---
+
+Adds `do_while_item` action and fixes several issues with Docker sandbox environments, particularly around Python/pip availability and repository setup reliability. The Codex agent Dockerfile was missing Python entirely, setup scripts were silently swallowing errors, and `~/.local/bin` wasn't on PATH—all of which caused repo setup failures that were difficult to diagnose.
+
+This release also introduces pytest plugin support, allowing pipelines to inject custom test behavior without modifying the tests themselves.
+
+Additionally, the `--max-tokens` CLI option enables longer model responses, and Ctrl-C now works correctly when using the `log` display mode.
+
+## Summary
+
+### Enhancements
+ - Added `--max-tokens` CLI option (`DF_MAX_TOKENS` for env) to override the default token limit (8096), enabling longer model responses.
+ - Add `do_while_item` action, which executes actions at least once and then repeatedly while a condition is true. Unlike `while_item`, the condition is evaluated after the actions, so iteration is 1 on the first condition check.
+ - Refactored `while_item` to align its iteration-counting behavior with `do_while_item`.
+ - Introduced `test_plugins_dir` parameter to `run_unit_tests` and `run_swe_agent`, allowing pytest plugins to be mounted and auto-loaded in sandbox containers.
+ - Pipeline parameters are now logged at startup, making it easier to see which parameters were actually used.
+ - Active pytest plugins and environment variables are logged when set.
+
+### Bug Fixes
+ - Fixed `setup-repo.sh` swallowing errors by running setup scripts with `bash -e`, so failures propagate instead of being silently ignored.
+ - Fixed Codex agent Dockerfile missing Python and pip entirely, which caused repo setup scripts to fail.
+ - Fixed permissions issue in Codex Dockerfile where `setup-repo.sh` copy required root.
+ - Added `~/.local/bin` to PATH in sandbox and agent Dockerfiles to quiet pip warnings and ensure installed executables are findable.
+ - Set `PIP_BREAK_SYSTEM_PACKAGES=1` in Codex Dockerfile to allow pip installs without a virtual environment.
+ - Set `HOMEBREW_NO_AUTO_UPDATE=1` in Codex Dockerfile to reduce noise and improve build speed.
+ - Fixed Ctrl-C not working when `--display` is `log`. Both the full and log displays can now be cleanly exited.
+ - Ensured `updated_at` is set on first run so it is always present in item metadata.
+
+## Dependencies
+
+### Upgraded
+- `openai` v1.68.2 -> v1.72.0
+
+## Actions
+
+### Added
+
+#### Item
+
+`do_while_item`
+: Executes actions at least once, then continues while a condition is true. Complements the existing `while_item` action.
+
+### Updated
+
+#### Item
+
+`while_item`
+: Aligned iteration counter to increment before the loop body, matching `do_while_item` semantics.
+
+`run_swe_agent`
+: Added `test_plugins_dir` parameter for mounting pytest plugins into the agent container.
+
+`run_unit_tests`
+: Added `test_plugins_dir` parameter for mounting pytest plugins into the sandbox container.
+
+`set_item_metadata`
+: Set `updated_at` on first run so it always exists in metadata.
+
+---
+
+Notice how:
+- The opening paragraph names `do_while_item` directly instead of saying "new looping capabilities"
+- Enhancements explain behavioral semantics ("Unlike `while_item`, the condition is evaluated after the actions...")
+- The `while_item` refactor is listed as an enhancement because it changes observable behavior
+- Bug fixes describe outcomes ("Both the full and log displays can now be cleanly exited") not implementation ("by raising `KeyboardInterrupt`")
+- Secondary identifiers use parenthetical format: `--max-tokens` CLI option (`DF_MAX_TOKENS` for env)
+- No spaces around em dashes

--- a/README.md
+++ b/README.md
@@ -8,21 +8,24 @@ in the dataset.
 
 For details on which actions are supported, see the [actions](docs/actions.md) documentation.
 
-## Setup
+## Installation
 
-1. Clone the repository
-2. Create a virtual environment:
+1. Install the package:
    ```bash
-   python -m venv venv
-   source venv/bin/activate  # On Windows: venv\Scripts\activate
+   pip install dataset-foundry
    ```
-3. Install the package:
-   ```bash
-   pip install -e .
+
+2. Create a `.env` file in the project root:
    ```
-4. Create a `.env` file in the project root with your OpenAI API key:
-   ```
-   OPENAI_API_KEY=your_api_key_here
+   # Provider API keys
+   OPENAI_API_KEY=
+   ANTHROPIC_API_KEY=
+
+   # Command-line defaults
+   DF_MODEL=anthropic/claude-sonnet-4-20250514
+
+   # Keep full display open after finishing so you can browse the results
+   # DF_NO_EXIT=true
    ```
 
 ### Default Settings

--- a/docs/actions.md
+++ b/docs/actions.md
@@ -72,6 +72,20 @@ Executes a pipeline of steps on an item. Does not execute the setup or teardown 
 **Parameters:**
 - `pipeline` (Union[Callable,Key,ItemPipeline,str]): The pipeline defining step to execute
 
+### `do_while_item`
+Executes actions at least once and then repeatedly while a condition is true.
+
+**Parameters:**
+- `actions` (list): Actions to execute while condition is true
+- `condition` (str): The condition to evaluate
+- `max_iterations` (int): Maximum number of iterations (default: 10)
+
+For both `while_item` and `do_while_item`, the condition receives an `iteration` variable that
+represents the number of completed iterations at the time the condition is evaluated. For
+`while_item`, `iteration` is 0 on the first evaluation because the body has not yet run. For
+`do_while_item`, the body executes once before the first evaluation, so `iteration` is 1 on the
+first condition check.
+
 ### `generate_item`
 Generates a data item using a language model, storing the result as either the entire data for a
 data item, or, if specified, as data underneath the property specified by `output_key`.

--- a/src/dataset_foundry/actions/item/do_while_item.py
+++ b/src/dataset_foundry/actions/item/do_while_item.py
@@ -1,0 +1,50 @@
+import logging
+
+from ...core.context import Context
+from ...core.dataset_item import DatasetItem
+from ...types.item_action import ItemAction
+from ...utils.eval.item_eval import item_eval
+
+logger = logging.getLogger(__name__)
+
+
+def do_while_item(actions: list, condition: str, max_iterations: int = 10) -> ItemAction:
+    """
+    Creates an action that executes a list of actions at least once and then continues executing
+    them while a given condition is met.
+
+    The `iteration` variable passed into the condition represents the number of completed iterations
+    at the time the condition is evaluated. For `do_while_item`, the actions execute once before the
+    first evaluation, so `iteration` is 1 on the first condition check.
+
+    Args:
+        actions (list): A list of actions to execute while the condition is true.
+        condition (str): A string representing the condition to evaluate.
+        max_iterations (int): The maximum number of iterations to execute. Defaults to 10.
+
+    Returns:
+        function: A function that takes a DatasetItem and Context and executes the
+            actions at least once and then while the condition is true.
+    """
+
+    async def do_while_item_action(item: DatasetItem, context: Context):
+        iterations = 0
+
+        # TODO: Think about whether we want to bind `**item.data` here to make things simpler. I
+        #       think other item actions are doing this [fastfedora 3.Mar.2025]
+        while True:
+            iterations += 1
+            logger.debug(
+                f"Executing do-while loop iteration {iterations} for condition '{condition}'."
+            )
+            for action in actions:
+                await action(item, context)
+
+            if not item_eval(condition, item, context, {"iteration": iterations}):
+                break
+
+            if iterations >= max_iterations:
+                logger.warning(f"Reached maximum of {max_iterations} iterations for '{condition}'.")
+                break
+
+    return do_while_item_action

--- a/src/dataset_foundry/actions/item/run_swe_agent.py
+++ b/src/dataset_foundry/actions/item/run_swe_agent.py
@@ -20,6 +20,7 @@ def run_swe_agent(
         output_dir: Union[Callable, Key, str] = Key("context.output_dir"),
         agent: Union[Callable, Key, str] = Key("context.swe_agent.type"),
         repo_path: Optional[Union[Callable, Key, str]] = None,
+        test_plugins_dir: Optional[Union[Callable, Key, str]] = None,
         timeout: Union[Callable, Key, int] = 3600,  # 1 hour default
         max_retries: Union[Callable, Key, int] = 3,
         output_key: Union[Callable, Key, str] = "agent_result",
@@ -36,6 +37,7 @@ def run_swe_agent(
         output_dir: Directory where agent output should be saved
         agent: Name of the agent to run (e.g., "codex", "claude-code")
         repo_path: Optional path to pre-existing repository
+        test_plugins_dir: Optional directory containing pytest plugins to mount in the container
         timeout: Maximum execution time in seconds
         max_retries: Maximum number of retry attempts
         output_key: Key to store the agent result in item data
@@ -51,6 +53,7 @@ def run_swe_agent(
         resolved_output_dir = resolve_item_value(output_dir, item, context, required_as="output_dir")
         resolved_agent = resolve_item_value(agent, item, context, required_as="agent")
         resolved_repo_path = resolve_item_value(repo_path, item, context) if repo_path else None
+        resolved_test_plugins_dir = resolve_item_value(test_plugins_dir, item, context)
         resolved_timeout = resolve_item_value(timeout, item, context)
         resolved_max_retries = resolve_item_value(max_retries, item, context)
         resolved_output_key = resolve_item_value(output_key, item, context)
@@ -68,6 +71,9 @@ def run_swe_agent(
                 "id": item.id,
                 **item.data
             })
+
+        if isinstance(resolved_test_plugins_dir, str):
+            resolved_test_plugins_dir = Path(resolved_test_plugins_dir)
 
         output_path = Path(resolved_output_dir)
         output_path.mkdir(parents=True, exist_ok=True)
@@ -93,6 +99,7 @@ def run_swe_agent(
                 result = await agent_runner.run(
                     inputs=agent_inputs,
                     output_dir=output_path,
+                    test_plugins_dir=resolved_test_plugins_dir,
                     timeout=resolved_timeout,
                     attempt=attempt + 1,
                     stream_logs=resolved_stream_logs

--- a/src/dataset_foundry/actions/item/run_unit_tests.py
+++ b/src/dataset_foundry/actions/item/run_unit_tests.py
@@ -27,6 +27,7 @@ def run_unit_tests(
         property: Union[Callable,Key,str] = "test_result",
         setup_property: Union[Callable,Key,str] = "setup_result",
         sandbox: Optional[Union[Callable,Key,str]] = None,
+        test_plugins_dir: Optional[Union[Callable,Key,str,Path]] = None,
         stream_logs: Union[Callable,Key,bool] = False,
         timeout: Union[Callable,Key,int] = 300,
     ) -> ItemAction:
@@ -36,6 +37,7 @@ def run_unit_tests(
         resolved_property = resolve_item_value(property, item, context, required_as="property")
         resolved_setup_property = resolve_item_value(setup_property, item, context)
         resolved_sandbox = resolve_item_value(sandbox, item, context)
+        resolved_test_plugins_dir = resolve_item_value(test_plugins_dir, item, context)
         resolved_stream_logs = resolve_item_value(stream_logs, item, context)
         resolved_timeout = resolve_item_value(timeout, item, context)
 
@@ -45,12 +47,16 @@ def run_unit_tests(
             else:
                 raise ValueError("Sandbox must be a string name of a sandbox")
 
+            if isinstance(resolved_test_plugins_dir, str):
+                resolved_test_plugins_dir = Path(resolved_test_plugins_dir)
+
             command = [f"python -m pytest -v '{resolved_filename}'"]
 
             logger.info(f"Running tests in sandbox with command: {' '.join(command)}")
             sandbox_result = await sandbox_manager.run(
                 target_file=resolved_filename,
                 workspace_dir=resolved_dir,
+                test_plugins_dir=resolved_test_plugins_dir,
                 command=command,
                 timeout=resolved_timeout,
                 stream_logs=resolved_stream_logs

--- a/src/dataset_foundry/actions/item/set_item_metadata.py
+++ b/src/dataset_foundry/actions/item/set_item_metadata.py
@@ -43,6 +43,7 @@ def set_item_metadata(
 
         else:
             metadata["created_at"] = run_at
+            metadata["updated_at"] = run_at
             metadata.setdefault("initial", {
                 "pipeline": get_pipeline_metadata(context),
                 "model": context.model.info,

--- a/src/dataset_foundry/actions/item/while_item.py
+++ b/src/dataset_foundry/actions/item/while_item.py
@@ -11,6 +11,10 @@ def while_item(condition: str, actions: list, max_iterations: int = 10) -> ItemA
     """
     Creates an action that executes a list of actions while a given condition is met.
 
+    The `iteration` variable passed into the condition represents the number of completed iterations
+    at the time the condition is evaluated. On the first evaluation, `iteration` is 0 because the
+    actions have not yet executed.
+
     Args:
         condition (str): A string representing the condition to evaluate.
         actions (list): A list of actions to execute if the condition is true.
@@ -26,10 +30,10 @@ def while_item(condition: str, actions: list, max_iterations: int = 10) -> ItemA
         # TODO: Think about whether we want to bind `**item.data` here to make things simpler. I
         #       think other item actions are doing this [fastfedora 3.Mar.2025]
         while item_eval(condition, item, context, { 'iteration': iterations }):
-            logger.debug(f"Condition '{condition}' met. Executing loop {iterations + 1}.")
+            iterations += 1
+            logger.debug(f"Condition '{condition}' met. Executing loop {iterations}.")
             for action in actions:
                 await action(item, context)
-            iterations += 1
 
             if iterations >= max_iterations:
                 logger.warning(f"Reached maximum of {max_iterations} iterations for '{condition}'.")

--- a/src/dataset_foundry/cli/config.py
+++ b/src/dataset_foundry/cli/config.py
@@ -12,6 +12,7 @@ LOG_DIR = OUTPUT_ROOT / "logs"
 # Model configuration
 DEFAULT_MODEL = "openai/gpt-4o-mini"
 DEFAULT_MODEL_TEMPERATURE = 0.7
+DEFAULT_MAX_TOKENS = 8096
 DEFAULT_NUM_SAMPLES = 10
 
 # Pipeline configuration

--- a/src/dataset_foundry/cli/main.py
+++ b/src/dataset_foundry/cli/main.py
@@ -158,6 +158,7 @@ async def main_cli():
 
     module = import_module(args["pipeline"])
     logger.info(f"Loaded pipeline: {args['pipeline']}")
+    logger.info(f"Pipeline parameters: {pipeline_parameters}")
 
     await display.run_pipeline(module.pipeline, params={ **args, **pipeline_parameters })
 

--- a/src/dataset_foundry/cli/main.py
+++ b/src/dataset_foundry/cli/main.py
@@ -10,8 +10,13 @@ from ..utils.imports.import_module import import_module
 from ..utils.params.parse_dir_arg import parse_dir_arg
 from .advanced_argparse import AdvancedArgumentParser
 from .config import DATASET_DIR, LOG_DIR
-from .config import DEFAULT_MODEL, DEFAULT_MODEL_TEMPERATURE, DEFAULT_NUM_SAMPLES
-from .config import DEFAULT_MAX_CONCURRENT_ITEMS
+from .config import (
+    DEFAULT_MAX_CONCURRENT_ITEMS,
+    DEFAULT_MAX_TOKENS,
+    DEFAULT_MODEL,
+    DEFAULT_MODEL_TEMPERATURE,
+    DEFAULT_NUM_SAMPLES,
+)
 
 logger = logging.getLogger(__name__)
 
@@ -92,6 +97,13 @@ async def main_cli():
         help=f"Temperature for generation (default: {DEFAULT_MODEL_TEMPERATURE})"
     )
     parser.add_argument(
+        "--max-tokens",
+        type=int,
+        env="DF_MAX_TOKENS",
+        default=DEFAULT_MAX_TOKENS,
+        help=f"Maximum tokens for model output (default: {DEFAULT_MAX_TOKENS})"
+    )
+    parser.add_argument(
         "--display",
         type=str,
         env="DF_DISPLAY",
@@ -133,7 +145,8 @@ async def main_cli():
     args["log_dir"] = parse_dir_arg(args["log_dir"], LOG_DIR / args["dataset"], True)
     args["model"] = Model(
         model=args["model"],
-        temperature=args["temperature"]
+        temperature=args["temperature"],
+        max_tokens=args["max_tokens"],
     )
 
     pipeline_parameters = {

--- a/src/dataset_foundry/cli/main.py
+++ b/src/dataset_foundry/cli/main.py
@@ -161,17 +161,19 @@ async def main_cli():
 
     await display.run_pipeline(module.pipeline, params={ **args, **pipeline_parameters })
 
-# Set up signal handler for graceful interruption
 def signal_handler(_signum, _frame):
     print("\nReceived interrupt signal, shutting down gracefully...")
-    # Let the asyncio event loop handle the shutdown
-    # This allows running tasks to clean up properly
+    raise KeyboardInterrupt()
 
 signal.signal(signal.SIGINT, signal_handler)
 signal.signal(signal.SIGTERM, signal_handler)
 
 def main():
-    asyncio.run(main_cli())
+    try:
+        asyncio.run(main_cli())
+    except KeyboardInterrupt:
+        # Interrupt handled; exit without traceback
+        pass
 
 if __name__ == "__main__":
-    asyncio.run(main_cli())
+    main()

--- a/src/dataset_foundry/configs/agents/claude_code/Dockerfile
+++ b/src/dataset_foundry/configs/agents/claude_code/Dockerfile
@@ -70,7 +70,7 @@ USER node
 
 # Install global packages
 ENV NPM_CONFIG_PREFIX=/usr/local/share/npm-global
-ENV PATH=$PATH:/usr/local/share/npm-global/bin
+ENV PATH="$HOME/.local/bin:/usr/local/share/npm-global/bin:${PATH}"
 
 # Install Claude
 RUN npm install -g @anthropic-ai/claude-code

--- a/src/dataset_foundry/configs/agents/codex/Dockerfile
+++ b/src/dataset_foundry/configs/agents/codex/Dockerfile
@@ -23,6 +23,8 @@ USER linuxbrew
 
 ENV HOMEBREW_NO_AUTO_UPDATE=1
 
+ENV PATH="$HOME/.local/bin:${PATH}"
+
 RUN brew install --cask codex
 
 WORKDIR /workspace

--- a/src/dataset_foundry/configs/agents/codex/Dockerfile
+++ b/src/dataset_foundry/configs/agents/codex/Dockerfile
@@ -1,10 +1,22 @@
 FROM homebrew/ubuntu22.04
 USER root
 
-# Install system dependencies
+# Install system dependencies, including Python and pip for repo setup scripts
 RUN apt-get update && \
-    apt-get install -y curl git build-essential software-properties-common && \
+    apt-get install -y \
+      curl \
+      git \
+      build-essential \
+      software-properties-common \
+      python3 \
+      python3-pip \
+      python3-venv \
+      python3-dev && \
     rm -rf /var/lib/apt/lists/*
+
+# Provide common `python` / `pip` entrypoints expected by repos
+RUN ln -sf /usr/bin/python3 /usr/bin/python && \
+    ln -sf /usr/bin/pip3 /usr/bin/pip
 
 # brew expects to run as a non-root user
 USER linuxbrew

--- a/src/dataset_foundry/configs/agents/codex/Dockerfile
+++ b/src/dataset_foundry/configs/agents/codex/Dockerfile
@@ -33,10 +33,14 @@ ENV PYTHONUNBUFFERED=1
 # Allow Python packages to be installed without a virtual environment
 ENV PIP_BREAK_SYSTEM_PACKAGES="1"
 
+USER root
+
 # Copy the setup-repo script. The Docker build context is `configs` (see `sandbox.yml`), so these
 # paths are relative to `src/dataset_foundry/configs`.
 COPY shared/setup-repo.sh /usr/local/bin/setup-repo.sh
 RUN chmod +x /usr/local/bin/setup-repo.sh
+
+USER linuxbrew
 
 # Default command (will be overridden by entrypoint)
 ENTRYPOINT ["sh", "-c", "/usr/local/bin/setup-repo.sh \"$REPO_DIR\" && exec \"$@\"", "--"]

--- a/src/dataset_foundry/configs/sandboxes/python/Dockerfile
+++ b/src/dataset_foundry/configs/sandboxes/python/Dockerfile
@@ -10,6 +10,9 @@ ENV PIP_BREAK_SYSTEM_PACKAGES="1"
 # Prevent pip from checking for new versions & cluttering up stderr with warnings
 ENV PIP_DISABLE_PIP_VERSION_CHECK="1"
 
+# Ensure local bin directory is in PATH to quiet pip warning
+ENV PATH="$HOME/.local/bin:${PATH}"
+
 # Install system dependencies
 RUN apt-get update && apt-get install -y \
     git \

--- a/src/dataset_foundry/configs/shared/setup-repo.sh
+++ b/src/dataset_foundry/configs/shared/setup-repo.sh
@@ -24,7 +24,7 @@ cd "$dir" 2>/dev/null || {
 if [ -f "script/setup" ]; then
     echo "Running setup script..."
     chmod u+x script/*
-    ./script/setup
+    bash -e ./script/setup
 elif [ -f "requirements.txt" ]; then
     echo "Installing dependencies from requirements.txt..."
     pip install -r requirements.txt

--- a/src/dataset_foundry/core/model.py
+++ b/src/dataset_foundry/core/model.py
@@ -6,26 +6,35 @@ from langchain_core.messages import BaseMessage
 from langchain_openai import ChatOpenAI
 from langchain_anthropic import ChatAnthropic
 
-MAX_TOKENS = 8096
+DEFAULT_MAX_TOKENS = 8096
 
 logger = logging.getLogger(__name__)
+
 
 class Model:
     _provider: str
     _model_name: str
     _model: BaseChatModel
     _temperature: float | None
+    _max_tokens: int
 
-    def __init__(self, model: str, temperature: float | None = None):
+    def __init__(
+        self,
+        model: str,
+        temperature: float | None = None,
+        max_tokens: int | None = None,
+    ):
         provider, model_name = Model._parse_model_string(model)
 
         self._provider = provider
         self._model_name = model_name
         self._temperature = temperature
+        self._max_tokens = max_tokens if max_tokens is not None else DEFAULT_MAX_TOKENS
 
         if provider == "openai":
             args = {
                 "model": model_name,
+                "max_tokens": self._max_tokens,
                 **({
                     "temperature": temperature,
                 } if temperature is not None and model_name not in ['o1-mini', 'o3-mini'] else {}),
@@ -35,7 +44,7 @@ class Model:
             self._model = ChatAnthropic(
                 model=model_name,
                 temperature=temperature,
-                max_tokens=MAX_TOKENS
+                max_tokens=self._max_tokens,
             )
         else:
             raise ValueError(f"Unsupported model provider: {provider}")
@@ -66,6 +75,7 @@ class Model:
             "name": self._model_name,
             "kwargs": self._model.model_kwargs,
             "temperature": self._temperature,
+            "max_tokens": self._max_tokens,
         }
 
     async def ainvoke(self, messages: List[BaseMessage], **kwargs) -> BaseMessage:

--- a/src/dataset_foundry/utils/docker/agent_runner.py
+++ b/src/dataset_foundry/utils/docker/agent_runner.py
@@ -69,6 +69,7 @@ class AgentRunner(BaseRunner):
         self,
         inputs: AgentInputs,
         output_dir: Path,
+        test_plugins_dir: Optional[Path] = None,
         timeout: int = 3600,
         attempt: int = 1,
         stream_logs: bool = False
@@ -92,7 +93,7 @@ class AgentRunner(BaseRunner):
 
             await self._ensure_image_built(stream_logs)
 
-            container_config = self._prepare_container_config(inputs, output_dir)
+            container_config = self._prepare_container_config(inputs, output_dir, test_plugins_dir)
 
             logger.info(f"Running agent {self.runner_name} (attempt {attempt})")
             container_result = await self.container_manager.run_container(
@@ -114,7 +115,8 @@ class AgentRunner(BaseRunner):
     def _prepare_container_config(
         self,
         inputs: AgentInputs,
-        output_dir: Path
+        output_dir: Path,
+        test_plugins_dir: Optional[Path] = None,
     ) -> ContainerConfig:
         """Prepare container configuration for agent execution."""
 
@@ -167,6 +169,7 @@ class AgentRunner(BaseRunner):
         if inputs.skip_repo_setup:
             environment["SKIP_REPO_SETUP"] = "1"
         self._prepare_environment_config(config, environment)
+        self._prepare_test_plugins_config(config, test_plugins_dir)
 
         return config
 

--- a/src/dataset_foundry/utils/docker/base_runner.py
+++ b/src/dataset_foundry/utils/docker/base_runner.py
@@ -191,3 +191,49 @@ class BaseRunner:
             config.environment.update(environment)
 
         config.environment = resolve_environment_dict(config.environment)
+
+    def _prepare_test_plugins_config(
+        self,
+        config: ContainerConfig,
+        test_plugins_dir: Optional[Path] = None
+    ) -> None:
+        """
+        Configure pytest plugins for the container.
+
+        If `test_plugins_dir` is provided, mounts it read-only at `/pytest-plugins` inside the
+        container and prepends `/pytest-plugins` to `PYTHONPATH` so that any modules in the
+        directory can be imported by Python code running in the container.
+        """
+        if not test_plugins_dir:
+            return
+
+        test_plugins_dir = test_plugins_dir.resolve()
+        if not test_plugins_dir.exists() or not test_plugins_dir.is_dir():
+            raise ValueError(
+                f"Test plugins directory {test_plugins_dir} does not exist or is not a directory"
+            )
+
+        if not config.volumes:
+            config.volumes = []
+
+        config.volumes.append(
+            Mount(target="/pytest-plugins", source=str(test_plugins_dir), type="bind", read_only=True)
+        )
+
+        if not config.environment:
+            config.environment = {}
+
+        pythonpath = config.environment.get("PYTHONPATH") or ""
+        if pythonpath:
+            pythonpath = ":" + pythonpath
+        config.environment["PYTHONPATH"] = "/pytest-plugins" + pythonpath
+
+        # Configure pytest plugins so they are loaded automatically when pytest runs in the sandbox.
+        pytest_plugins = config.environment.get("PYTEST_PLUGINS") or ""
+
+        for test_plugin_file in sorted(test_plugins_dir.glob("*.py")):
+            name = test_plugin_file.stem
+            pytest_plugins = f"{pytest_plugins},{name}" if pytest_plugins else name
+
+        if pytest_plugins:
+            config.environment["PYTEST_PLUGINS"] = pytest_plugins

--- a/src/dataset_foundry/utils/docker/base_runner.py
+++ b/src/dataset_foundry/utils/docker/base_runner.py
@@ -237,3 +237,7 @@ class BaseRunner:
 
         if pytest_plugins:
             config.environment["PYTEST_PLUGINS"] = pytest_plugins
+
+        if config.environment:
+            logger.info(f"Configured pytest plugins: {pytest_plugins}")
+            logger.info(f"Environment: {config.environment}")

--- a/src/dataset_foundry/utils/docker/sandbox_runner.py
+++ b/src/dataset_foundry/utils/docker/sandbox_runner.py
@@ -8,7 +8,6 @@ from pathlib import Path
 from typing import List, Optional
 
 from docker.types import Mount
-from pydantic import BaseModel
 
 from .base_runner import BaseRunner, RunnerConfig
 from .container_manager import ContainerConfig, ContainerResult
@@ -40,6 +39,7 @@ class SandboxRunner(BaseRunner):
         self,
         target_file: Path,
         workspace_dir: Path,
+        test_plugins_dir: Optional[Path] = None,
         command: Optional[List[str]] = None,
         timeout: int = 300,
         stream_logs: bool = False
@@ -50,6 +50,7 @@ class SandboxRunner(BaseRunner):
         Args:
             target_file: Path to the target file to execute
             workspace_dir: Directory containing all files to mount
+            test_plugins_dir: Optional directory containing pytest plugins to mount
             command: Optional command to override the default
             timeout: Timeout for execution in seconds (default: 300)
             stream_logs: Whether to stream container logs
@@ -66,6 +67,7 @@ class SandboxRunner(BaseRunner):
             container_config = self._create_container_config(
                 workspace_dir,
                 target_file,
+                test_plugins_dir,
                 command,
             )
 
@@ -94,6 +96,7 @@ class SandboxRunner(BaseRunner):
         self,
         workspace_dir: Path,
         target_file: Path,
+        test_plugins_dir: Optional[Path] = None,
         command: Optional[List[str]] = None
     ) -> ContainerConfig:
         """Create container configuration for the sandbox."""
@@ -112,5 +115,6 @@ class SandboxRunner(BaseRunner):
             Mount(target=working_dir, source=str(workspace_dir), type="bind", read_only=False)
         ])
         self._prepare_environment_config(config)
+        self._prepare_test_plugins_config(config, test_plugins_dir)
 
         return config


### PR DESCRIPTION
Adds `do_while_item` action and fixes several issues with Docker sandbox environments, particularly around Python/pip availability and repository setup reliability. The Codex agent Dockerfile was missing Python entirely, setup scripts were silently swallowing errors, and `~/.local/bin` wasn't on PATH—all of which caused repo setup failures that were difficult to diagnose. 

This release also introduces pytest plugin support, allowing pipelines to inject custom test behavior without modifying the tests themselves.

Additionally, the `--max-tokens` CLI option enables longer model responses, and Ctrl-C now works correctly when using the `log` display mode.

## Summary

### Enhancements
 - Added `--max-tokens` CLI option (`DF_MAX_TOKENS` for env) to override the default token limit (8096), enabling longer model responses.
  - Add `do_while_item` action, which executes actions at least once and then repeatedly while a condition is true. Unlike `while_item`, the condition is evaluated after the actions, so iteration is 1 on the first condition check.
  - Refactored `while_item` to align its iteration-counting behavior with `do_while_item`.
 - Introduced `test_plugins_dir` parameter to `run_unit_tests` and `run_swe_agent`, allowing pytest plugins to be mounted and auto-loaded in sandbox containers.
 - Pipeline parameters are now logged at startup, making it easier to see which parameters were actually used.
 - Active pytest plugins and environment variables are logged when set.
 - Added Claude Code skill for creating PR descriptions using the same format as this one.

### Bug Fixes
 - Fixed `setup-repo.sh` swallowing errors by running setup scripts with `bash -e`, so failures propagate instead of being silently ignored.
 - Fixed Codex agent Dockerfile missing Python and pip entirely, which caused repo setup scripts to fail.
 - Fixed permissions issue in Codex Dockerfile where `setup-repo.sh` copy required root.
 - Added `~/.local/bin` to PATH in sandbox and agent Dockerfiles to quiet pip warnings and ensure installed executables are findable.
 - Set `PIP_BREAK_SYSTEM_PACKAGES=1` in Codex Dockerfile to allow pip installs without a virtual environment.
 - Set `HOMEBREW_NO_AUTO_UPDATE=1` in Codex Dockerfile to reduce noise and improve build speed.
 - Fixed Ctrl-C not working when `--display` is `log`. Both the full and log displays can now be cleanly exited.
  - Ensured `updated_at` is set on first run so it is always present in item metadata.

## Actions

### Added

#### Item

`do_while_item`
: Executes actions at least once, then continues while a condition is true. Complements the existing `while_item` action.

### Updated

#### Item

`while_item`
: Aligned iteration counter to increment before the loop body, matching `do_while_item` semantics.

`run_swe_agent`
: Added `test_plugins_dir` parameter for mounting pytest plugins into the agent container.

`run_unit_tests`
: Added `test_plugins_dir` parameter for mounting pytest plugins into the sandbox container.

`set_item_metadata`
: Set `updated_at` on first run so it always exists in metadata.

